### PR TITLE
refactor: remove duplicated code

### DIFF
--- a/crates/swc_macro_wasm/examples/transform.rs
+++ b/crates/swc_macro_wasm/examples/transform.rs
@@ -1,0 +1,31 @@
+use std::fs;
+
+use serde_json::json;
+
+pub fn main() {
+    let path = std::env::args().nth(1).unwrap_or("test.js".to_owned());
+    let source = fs::read_to_string(path).unwrap();
+    let config = json!({
+        "build": {
+            "target": "production"
+        },
+        "device": {
+            "isMobile": false
+        },
+        "user": {
+            "language": "en",
+            "isLoggedIn": true
+        },
+        "experiment": {
+            "group": "B"
+        },
+        "featureFlags": {
+            "newMobileUI": true,
+            "enableNewFeature": false,
+            "newUserProfile": false
+        }
+    });
+
+    let ret = swc_macro_wasm::optimize::optimize(source, config);
+    println!("{}", ret);
+}

--- a/crates/swc_macro_wasm/src/lib.rs
+++ b/crates/swc_macro_wasm/src/lib.rs
@@ -1,100 +1,10 @@
-use swc_common::comments::SingleThreadedComments;
-use swc_common::pass::Repeated;
-use swc_common::sync::Lrc;
-use swc_common::{FileName, Mark, SourceMap};
-use swc_core::ecma::codegen;
-use swc_core::ecma::visit::VisitMutWith;
-use swc_ecma_ast::Program;
-use swc_ecma_codegen::text_writer::WriteJs;
-use swc_ecma_codegen::{Emitter, text_writer};
-use swc_ecma_parser::{EsSyntax, Parser, StringInput, Syntax};
-use swc_ecma_transforms_base::fixer::fixer;
-use swc_ecma_transforms_base::resolver;
-use swc_macro_condition_transform::condition_transform;
-use swc_macro_parser::MacroParser;
 use wasm_bindgen::prelude::*;
+
+pub mod optimize;
 
 #[wasm_bindgen]
 pub fn optimize(source: String, config: &str) -> String {
     let config: serde_json::Value =
         serde_json::from_str(config).expect("invalid config: must be a json object");
-
-    let cm: Lrc<SourceMap> = Default::default();
-    let (mut program, comments) = {
-        let fm = cm.new_source_file(FileName::Custom("test.js".to_string()).into(), source);
-        let comments = SingleThreadedComments::default();
-        let program = Parser::new(
-            Syntax::Es(EsSyntax::default()),
-            StringInput::from(&*fm),
-            Some(&comments),
-        )
-        .parse_program()
-        .unwrap();
-        (program, comments)
-    };
-
-    let macros = {
-        let parser = MacroParser::new("common");
-
-        parser.parse(&comments)
-    };
-
-    let program = {
-        let mut transformer = condition_transform(config, macros);
-        program.visit_mut_with(&mut transformer);
-
-        // Apply resolver and optimization
-        swc_common::GLOBALS.set(&Default::default(), || {
-            let unresolved_mark = Mark::new();
-            let top_level_mark = Mark::new();
-
-            program.mutate(resolver(unresolved_mark, top_level_mark, false));
-
-            perform_dce(&mut program, unresolved_mark);
-
-            program.mutate(fixer(Some(&comments)));
-
-            program
-        })
-    };
-
-    let ret = {
-        let mut buf = vec![];
-        let wr = Box::new(text_writer::JsWriter::new(cm.clone(), "\n", &mut buf, None))
-            as Box<dyn WriteJs>;
-        let mut emitter = Emitter {
-            cfg: codegen::Config::default().with_minify(false),
-            comments: Some(&comments),
-            cm: cm.clone(),
-            wr,
-        };
-        emitter.emit_program(&program).unwrap();
-        drop(emitter);
-
-        unsafe { String::from_utf8_unchecked(buf) }
-    };
-
-    ret
-}
-
-fn perform_dce(m: &mut Program, unresolved_mark: Mark) {
-    let mut visitor = swc_ecma_transforms_optimization::simplify::dce::dce(
-        swc_ecma_transforms_optimization::simplify::dce::Config {
-            module_mark: None,
-            top_level: true,
-            top_retain: Default::default(),
-            preserve_imports_with_side_effects: true,
-        },
-        unresolved_mark,
-    );
-
-    loop {
-        m.visit_mut_with(&mut visitor);
-
-        if !visitor.changed() {
-            break;
-        }
-
-        visitor.reset();
-    }
+    optimize::optimize(source, config)
 }

--- a/crates/swc_macro_wasm/src/optimize.rs
+++ b/crates/swc_macro_wasm/src/optimize.rs
@@ -1,27 +1,19 @@
-use std::fs;
-
-use serde_json::json;
+use swc_common::comments::SingleThreadedComments;
 use swc_common::pass::Repeated;
-use swc_core::{
-    common::{FileName, Mark, SourceMap, comments::SingleThreadedComments, sync::Lrc},
-    ecma::{
-        codegen::{
-            self, Emitter,
-            text_writer::{self, WriteJs},
-        },
-        parser::{EsSyntax, Parser, StringInput, Syntax},
-        visit::VisitMutWith,
-    },
-};
+use swc_common::sync::Lrc;
+use swc_common::{FileName, Mark, SourceMap};
+use swc_core::ecma::codegen;
+use swc_core::ecma::visit::VisitMutWith;
 use swc_ecma_ast::Program;
+use swc_ecma_codegen::text_writer::WriteJs;
+use swc_ecma_codegen::{Emitter, text_writer};
+use swc_ecma_parser::{EsSyntax, Parser, StringInput, Syntax};
+use swc_ecma_transforms_base::fixer::fixer;
 use swc_ecma_transforms_base::resolver;
 use swc_macro_condition_transform::condition_transform;
 use swc_macro_parser::MacroParser;
 
-pub fn main() {
-    let path = std::env::args().nth(1).unwrap_or("test.js".to_owned());
-    let source = fs::read_to_string(path).unwrap();
-
+pub fn optimize(source: String, config: serde_json::Value) -> String {
     let cm: Lrc<SourceMap> = Default::default();
     let (mut program, comments) = {
         let fm = cm.new_source_file(FileName::Custom("test.js".to_string()).into(), source);
@@ -43,38 +35,19 @@ pub fn main() {
     };
 
     let program = {
-        let mut transformer = condition_transform(
-            json!({
-                "build": {
-                    "target": "production"
-                },
-                "device": {
-                    "isMobile": false
-                },
-                "user": {
-                    "language": "en",
-                    "isLoggedIn": true
-                },
-                "experiment": {
-                    "group": "B"
-                },
-                "featureFlags": {
-                    "newMobileUI": true,
-                    "enableNewFeature": false,
-                    "newUserProfile": false
-                }
-            }),
-            macros,
-        );
+        let mut transformer = condition_transform(config, macros);
         program.visit_mut_with(&mut transformer);
 
         // Apply resolver and optimization
         swc_common::GLOBALS.set(&Default::default(), || {
             let unresolved_mark = Mark::new();
             let top_level_mark = Mark::new();
-            let mut program = program.apply(resolver(unresolved_mark, top_level_mark, false));
+
+            program.mutate(resolver(unresolved_mark, top_level_mark, false));
 
             perform_dce(&mut program, unresolved_mark);
+
+            program.mutate(fixer(Some(&comments)));
 
             program
         })
@@ -85,7 +58,7 @@ pub fn main() {
         let wr = Box::new(text_writer::JsWriter::new(cm.clone(), "\n", &mut buf, None))
             as Box<dyn WriteJs>;
         let mut emitter = Emitter {
-            cfg: codegen::Config::default(),
+            cfg: codegen::Config::default().with_minify(true),
             comments: Some(&comments),
             cm: cm.clone(),
             wr,
@@ -96,7 +69,7 @@ pub fn main() {
         unsafe { String::from_utf8_unchecked(buf) }
     };
 
-    println!("{}", ret);
+    ret
 }
 
 fn perform_dce(m: &mut Program, unresolved_mark: Mark) {


### PR DESCRIPTION
Move the example in `swc_macro_condition_transform` to `swc_macro_wasm` and share the `optimize` code with wasm. So we can always get the same result whether we run directly `cargo run --example transform` or run wasm.