### PR TITLE
WIP: feat: implement tree shaking

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -311,6 +311,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
+name = "foldhash"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
 name = "form_urlencoded"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -351,6 +357,11 @@ name = "hashbrown"
 version = "0.15.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "84b26c544d002229e640969970a2e74021aadf6e2f96372b9c58eff97de08eb3"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash",
+]
 
 [[package]]
 name = "heck"
@@ -672,6 +683,18 @@ checksum = "3672b37090dbd86368a4145bc067582552b29c27377cad4e0a306c97f9bd7772"
 dependencies = [
  "fixedbitset",
  "indexmap",
+]
+
+[[package]]
+name = "petgraph"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54acf3a685220b533e437e264e4d932cfbdc4cc7ec0cd232ed73c08d03b8a7ca"
+dependencies = [
+ "fixedbitset",
+ "hashbrown 0.15.3",
+ "indexmap",
+ "serde",
 ]
 
 [[package]]
@@ -1038,9 +1061,9 @@ dependencies = [
 
 [[package]]
 name = "swc_common"
-version = "11.0.3"
+version = "11.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4a057a154061e6af54d037b5366f0776033e57ee07bf710dfb88d2677d08eea"
+checksum = "44c332906667b0fa98622f19a19e43afa5aa63b652813f80645dd0f33eca1fbb"
 dependencies = [
  "anyhow",
  "ast_node",
@@ -1233,7 +1256,7 @@ dependencies = [
  "indexmap",
  "once_cell",
  "par-core",
- "petgraph",
+ "petgraph 0.7.1",
  "rustc-hash",
  "serde_json",
  "swc_atoms",
@@ -1249,9 +1272,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_utils"
-version = "15.0.1"
+version = "15.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "199e2f048c1998d550ebe5296e0876a3e5b2f963d75a925c2208466071edb9d8"
+checksum = "7d2c29dbfc54e02c14975aff9d2c75ae6fff0808d860d9971a493d37870e282f"
 dependencies = [
  "indexmap",
  "num_cpus",
@@ -1323,16 +1346,22 @@ dependencies = [
 name = "swc_macro_wasm"
 version = "0.1.0"
 dependencies = [
+ "indexmap",
+ "petgraph 0.8.2",
+ "rustc-hash",
  "serde_json",
+ "swc_atoms",
  "swc_common",
  "swc_core",
  "swc_ecma_ast",
  "swc_ecma_codegen",
  "swc_ecma_parser",
  "swc_ecma_transforms_base",
- "swc_ecma_transforms_optimization",
+ "swc_ecma_utils",
+ "swc_ecma_visit",
  "swc_macro_condition_transform",
  "swc_macro_parser",
+ "tracing",
  "wasm-bindgen",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1457,6 +1457,7 @@ dependencies = [
  "swc_macro_parser",
  "tracing",
  "wasm-bindgen",
+ "webpack_graph",
 ]
 
 [[package]]

--- a/crates/swc_macro_wasm/Cargo.toml
+++ b/crates/swc_macro_wasm/Cargo.toml
@@ -19,6 +19,7 @@ serde_json = { workspace = true }
 
 swc_macro_condition_transform = { workspace = true }
 swc_macro_parser = { workspace = true }
+webpack_graph = { workspace = true }
 indexmap = "2.9.0"
 petgraph = "0.8.2"
 swc_atoms = "5.0.0"

--- a/crates/swc_macro_wasm/Cargo.toml
+++ b/crates/swc_macro_wasm/Cargo.toml
@@ -14,9 +14,15 @@ swc_ecma_ast = "11.0.0"
 swc_ecma_codegen = "13.2.0"
 swc_ecma_parser = "14.0.1"
 swc_ecma_transforms_base = "15.1.0"
-swc_ecma_transforms_optimization = "16.0.0"
 wasm-bindgen = "0.2.100"
 serde_json = { workspace = true }
 
 swc_macro_condition_transform = { workspace = true }
 swc_macro_parser = { workspace = true }
+indexmap = "2.9.0"
+petgraph = "0.8.2"
+swc_atoms = "5.0.0"
+rustc-hash = "2.1.1"
+swc_ecma_utils = "15.0.2"
+swc_ecma_visit = "11.0.0"
+tracing = "0.1.41"

--- a/crates/swc_macro_wasm/src/dce.rs
+++ b/crates/swc_macro_wasm/src/dce.rs
@@ -1,0 +1,1212 @@
+//! Temporary copy of SWC DCE code to add support for PURE comments.
+
+use std::borrow::Cow;
+
+use indexmap::IndexSet;
+use petgraph::{Directed, Direction::Incoming, algo::tarjan_scc, prelude::GraphMap};
+use rustc_hash::{FxBuildHasher, FxHashMap, FxHashSet};
+use swc_atoms::{Atom, atom};
+use swc_common::{
+    DUMMY_SP, Mark, SyntaxContext,
+    pass::{CompilerPass, Repeated},
+    util::take::Take,
+};
+use swc_ecma_ast::*;
+use swc_ecma_transforms_base::perf::cpu_count;
+use swc_ecma_utils::{
+    ExprCtx, ExprExt, IsEmpty, ModuleItemLike, StmtLike, Value::Known, collect_decls, find_pat_ids,
+};
+use swc_ecma_visit::{
+    Visit, VisitMut, VisitMutWith, VisitWith, noop_visit_mut_type, noop_visit_type, visit_mut_pass,
+};
+use tracing::{Level, debug, span};
+
+pub fn dce(
+    config: Config,
+    unresolved_mark: Mark,
+) -> impl Pass + VisitMut + Repeated + CompilerPass {
+    visit_mut_pass(TreeShaker {
+        expr_ctx: ExprCtx {
+            unresolved_ctxt: SyntaxContext::empty().apply_mark(unresolved_mark),
+            is_unresolved_ref_safe: false,
+            in_strict: false,
+            remaining_depth: 2,
+        },
+        config,
+        changed: false,
+        pass: 0,
+        in_fn: false,
+        in_block_stmt: false,
+        var_decl_kind: None,
+        data: Default::default(),
+    })
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct Config {
+    /// If this [Mark] is applied to a function expression, it's treated as a
+    /// separate module.
+    ///
+    /// **Note**: This is hack to make operation parallel while allowing invalid
+    /// module produced by the `swc_bundler`.
+    pub module_mark: Option<Mark>,
+
+    /// If true, top-level items will be removed if they are not used.
+    ///
+    /// Defaults to `true`.
+    pub top_level: bool,
+
+    /// Declarations with a symbol in this set will be preserved.
+    pub top_retain: Vec<Atom>,
+
+    /// If false, imports with side effects will be removed.
+    pub preserve_imports_with_side_effects: bool,
+}
+
+impl Default for Config {
+    fn default() -> Self {
+        Self {
+            module_mark: Default::default(),
+            top_level: true,
+            top_retain: Default::default(),
+            preserve_imports_with_side_effects: true,
+        }
+    }
+}
+
+struct TreeShaker {
+    expr_ctx: ExprCtx,
+
+    config: Config,
+    changed: bool,
+    pass: u16,
+
+    in_fn: bool,
+    in_block_stmt: bool,
+    var_decl_kind: Option<VarDeclKind>,
+
+    data: Data,
+}
+
+impl CompilerPass for TreeShaker {
+    fn name(&self) -> Cow<'static, str> {
+        Cow::Borrowed("tree-shaker")
+    }
+}
+
+#[derive(Default)]
+struct Data {
+    initialized: bool,
+
+    used_names: FxHashMap<Id, VarInfo>,
+
+    /// Variable usage graph
+    ///
+    /// We use `u32` because [FastDiGraphMap] stores types as `(N, 1 bit)` so if
+    /// we use u32 it fits into the cache line of cpu.
+    graph: GraphMap<u32, VarInfo, Directed, FxBuildHasher>,
+    /// Entrypoints.
+    entries: FxHashSet<u32>,
+
+    graph_ix: IndexSet<Id, FxBuildHasher>,
+}
+
+impl Data {
+    fn drop_usage(&mut self, id: &Id) {
+        if let Some(e) = self.used_names.get_mut(id) {
+            // We use `saturating_sub` to avoid underflow.
+            // We subtract the cycle count from the occurence count, so the value is not
+            // correct representation of the actual usage.
+            e.usage = e.usage.saturating_sub(1);
+
+            if e.usage == 0 && e.assign == 0 {
+                if let Some(n) = self.get_node(id) {
+                    self.graph.remove_node(n);
+                }
+            }
+        } else if let Some(n) = self.get_node(id) {
+            self.graph.remove_node(n);
+        }
+    }
+
+    fn drop_assign(&mut self, id: &Id) {
+        if let Some(e) = self.used_names.get_mut(id) {
+            // We use `saturating_sub` to avoid underflow.
+            // We subtract the cycle count from the occurence count, so the value is not
+            // correct representation of the actual usage.
+            e.assign = e.assign.saturating_sub(1);
+
+            if e.usage == 0 && e.assign == 0 {
+                if let Some(n) = self.get_node(id) {
+                    self.graph.remove_node(n);
+                }
+            }
+        } else if let Some(n) = self.get_node(id) {
+            self.graph.remove_node(n);
+        }
+    }
+
+    fn get_node(&self, id: &Id) -> Option<u32> {
+        self.graph_ix.get_index_of(id).map(|ix| ix as _)
+    }
+
+    fn node(&mut self, id: &Id) -> u32 {
+        self.graph_ix.get_index_of(id).unwrap_or_else(|| {
+            let ix = self.graph_ix.len();
+            self.graph_ix.insert_full(id.clone());
+            ix
+        }) as _
+    }
+
+    /// Add an edge to dependency graph
+    fn add_dep_edge(&mut self, from: &Id, to: &Id, assign: bool) {
+        let from = self.node(from);
+        let to = self.node(to);
+
+        match self.graph.edge_weight_mut(from, to) {
+            Some(info) => {
+                if assign {
+                    info.assign += 1;
+                } else {
+                    info.usage += 1;
+                }
+            }
+            None => {
+                self.graph.add_edge(from, to, VarInfo {
+                    usage: u32::from(!assign),
+                    assign: u32::from(assign),
+                });
+            }
+        };
+    }
+
+    /// Traverse the graph and subtract usages from `used_names`.
+    fn subtract_cycles(&mut self) {
+        let cycles = tarjan_scc(&self.graph);
+
+        'c: for cycle in cycles {
+            if cycle.len() == 1 {
+                continue;
+            }
+
+            // We have to exclude cycle from remove list if an outer node refences an item
+            // of cycle.
+            for &node in &cycle {
+                // It's referenced by an outer node.
+                if self.entries.contains(&node) {
+                    continue 'c;
+                }
+
+                // If any node in cycle is referenced by an outer node, we
+                // should not remove the cycle
+                if self.graph.neighbors_directed(node, Incoming).any(|source| {
+                    // Node in cycle does not matter
+                    !cycle.contains(&source)
+                }) {
+                    continue 'c;
+                }
+            }
+
+            for &i in &cycle {
+                for &j in &cycle {
+                    if i == j {
+                        continue;
+                    }
+
+                    let id = self.graph_ix.get_index(j as _);
+                    let id = match id {
+                        Some(id) => id,
+                        None => continue,
+                    };
+
+                    if let Some(w) = self.graph.edge_weight(i, j) {
+                        let e = self.used_names.entry(id.clone()).or_default();
+                        e.usage -= w.usage;
+                        e.assign -= w.assign;
+                    }
+                }
+            }
+        }
+    }
+}
+
+/// Graph modification
+impl Data {
+    fn drop_ast_node<N>(&mut self, node: &N)
+    where
+        N: for<'aa> VisitWith<Dropper<'aa>>,
+    {
+        let mut dropper = Dropper { data: self };
+
+        node.visit_with(&mut dropper);
+    }
+}
+
+struct Dropper<'a> {
+    data: &'a mut Data,
+}
+
+impl Visit for Dropper<'_> {
+    fn visit_binding_ident(&mut self, node: &BindingIdent) {
+        node.visit_children_with(self);
+
+        self.data.drop_assign(&node.to_id());
+    }
+
+    fn visit_class_decl(&mut self, node: &ClassDecl) {
+        node.visit_children_with(self);
+
+        self.data.drop_assign(&node.ident.to_id());
+    }
+
+    fn visit_class_expr(&mut self, node: &ClassExpr) {
+        node.visit_children_with(self);
+
+        if let Some(i) = &node.ident {
+            self.data.drop_assign(&i.to_id());
+        }
+    }
+
+    fn visit_expr(&mut self, expr: &Expr) {
+        expr.visit_children_with(self);
+
+        if let Expr::Ident(i) = expr {
+            self.data.drop_usage(&i.to_id());
+        }
+    }
+
+    fn visit_fn_decl(&mut self, node: &FnDecl) {
+        node.visit_children_with(self);
+
+        self.data.drop_assign(&node.ident.to_id());
+    }
+
+    fn visit_fn_expr(&mut self, node: &FnExpr) {
+        node.visit_children_with(self);
+
+        if let Some(i) = &node.ident {
+            self.data.drop_assign(&i.to_id());
+        }
+    }
+
+    noop_visit_type!(fail);
+}
+
+#[derive(Debug, Default)]
+struct VarInfo {
+    /// This does not include self-references in a function.
+    pub usage: u32,
+    /// This does not include self-references in a function.
+    pub assign: u32,
+}
+
+struct Analyzer<'a> {
+    #[allow(dead_code)]
+    config: &'a Config,
+    in_var_decl: bool,
+    scope: Scope<'a>,
+    data: &'a mut Data,
+    cur_class_id: Option<Id>,
+    cur_fn_id: Option<Id>,
+}
+
+#[derive(Debug, Default)]
+struct Scope<'a> {
+    parent: Option<&'a Scope<'a>>,
+    kind: ScopeKind,
+
+    bindings_affected_by_eval: FxHashSet<Id>,
+    found_direct_eval: bool,
+
+    found_arguemnts: bool,
+    bindings_affected_by_arguements: Vec<Id>,
+
+    /// Used to construct a graph.
+    ///
+    /// This includes all bindings to current node.
+    ast_path: Vec<Id>,
+}
+
+#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+enum ScopeKind {
+    Fn,
+    ArrowFn,
+}
+
+impl Default for ScopeKind {
+    fn default() -> Self {
+        Self::Fn
+    }
+}
+
+impl Analyzer<'_> {
+    fn with_ast_path<F>(&mut self, ids: Vec<Id>, op: F)
+    where
+        F: for<'aa> FnOnce(&mut Analyzer<'aa>),
+    {
+        let prev_len = self.scope.ast_path.len();
+
+        self.scope.ast_path.extend(ids);
+
+        op(self);
+
+        self.scope.ast_path.truncate(prev_len);
+    }
+
+    fn with_scope<F>(&mut self, kind: ScopeKind, op: F)
+    where
+        F: for<'aa> FnOnce(&mut Analyzer<'aa>),
+    {
+        let child_scope = {
+            let child = Scope {
+                parent: Some(&self.scope),
+                ..Default::default()
+            };
+
+            let mut v = Analyzer {
+                scope: child,
+                data: self.data,
+                cur_fn_id: self.cur_fn_id.clone(),
+                cur_class_id: self.cur_class_id.clone(),
+                ..*self
+            };
+
+            op(&mut v);
+
+            Scope {
+                parent: None,
+                ..v.scope
+            }
+        };
+
+        // If we found eval, mark all declarations in scope and upper as used
+        if child_scope.found_direct_eval {
+            for id in child_scope.bindings_affected_by_eval {
+                self.data.used_names.entry(id).or_default().usage += 1;
+            }
+
+            self.scope.found_direct_eval = true;
+        }
+
+        if child_scope.found_arguemnts {
+            // Parameters
+
+            for id in child_scope.bindings_affected_by_arguements {
+                self.data.used_names.entry(id).or_default().usage += 1;
+            }
+
+            if !matches!(kind, ScopeKind::Fn) {
+                self.scope.found_arguemnts = true;
+            }
+        }
+    }
+
+    /// Mark `id` as used
+    fn add(&mut self, id: Id, assign: bool) {
+        if id.0 == atom!("arguments") {
+            self.scope.found_arguemnts = true;
+        }
+
+        if let Some(f) = &self.cur_fn_id {
+            if id == *f {
+                return;
+            }
+        }
+        if let Some(f) = &self.cur_class_id {
+            if id == *f {
+                return;
+            }
+        }
+
+        if self.scope.is_ast_path_empty() {
+            // Add references from top level items into graph
+            let idx = self.data.node(&id);
+            self.data.entries.insert(idx);
+        } else {
+            let mut scope = Some(&self.scope);
+
+            while let Some(s) = scope {
+                for component in &s.ast_path {
+                    self.data.add_dep_edge(component, &id, assign);
+                }
+
+                if s.kind == ScopeKind::Fn && !s.ast_path.is_empty() {
+                    break;
+                }
+
+                scope = s.parent;
+            }
+        }
+
+        if assign {
+            self.data.used_names.entry(id).or_default().assign += 1;
+        } else {
+            self.data.used_names.entry(id).or_default().usage += 1;
+        }
+    }
+}
+
+impl Visit for Analyzer<'_> {
+    noop_visit_type!();
+
+    fn visit_callee(&mut self, n: &Callee) {
+        n.visit_children_with(self);
+
+        if let Callee::Expr(e) = n {
+            if e.is_ident_ref_to("eval") {
+                self.scope.found_direct_eval = true;
+            }
+        }
+    }
+
+    fn visit_assign_pat_prop(&mut self, n: &AssignPatProp) {
+        n.visit_children_with(self);
+
+        self.add(n.key.to_id(), true);
+    }
+
+    fn visit_class_decl(&mut self, n: &ClassDecl) {
+        self.with_ast_path(vec![n.ident.to_id()], |v| {
+            let old = v.cur_class_id.take();
+            v.cur_class_id = Some(n.ident.to_id());
+            n.visit_children_with(v);
+            v.cur_class_id = old;
+
+            if !n.class.decorators.is_empty() {
+                v.add(n.ident.to_id(), false);
+            }
+        })
+    }
+
+    fn visit_class_expr(&mut self, n: &ClassExpr) {
+        n.visit_children_with(self);
+
+        if !n.class.decorators.is_empty() {
+            if let Some(i) = &n.ident {
+                self.add(i.to_id(), false);
+            }
+        }
+    }
+
+    fn visit_export_named_specifier(&mut self, n: &ExportNamedSpecifier) {
+        if let ModuleExportName::Ident(orig) = &n.orig {
+            self.add(orig.to_id(), false);
+        }
+    }
+
+    fn visit_export_decl(&mut self, n: &ExportDecl) {
+        let name = match &n.decl {
+            Decl::Class(c) => vec![c.ident.to_id()],
+            Decl::Fn(f) => vec![f.ident.to_id()],
+            Decl::Var(v) => v
+                .decls
+                .iter()
+                .flat_map(|d| find_pat_ids(d).into_iter())
+                .collect(),
+            _ => Vec::new(),
+        };
+        for ident in name {
+            self.add(ident, false);
+        }
+
+        n.visit_children_with(self)
+    }
+
+    fn visit_expr(&mut self, e: &Expr) {
+        let old_in_var_decl = self.in_var_decl;
+
+        self.in_var_decl = false;
+        e.visit_children_with(self);
+
+        if let Expr::Ident(i) = e {
+            self.add(i.to_id(), false);
+        }
+
+        self.in_var_decl = old_in_var_decl;
+    }
+
+    fn visit_assign_expr(&mut self, n: &AssignExpr) {
+        match n.op {
+            op!("=") => {
+                if let Some(i) = n.left.as_ident() {
+                    self.add(i.to_id(), true);
+                    n.right.visit_with(self);
+                } else {
+                    n.visit_children_with(self);
+                }
+            }
+            _ => {
+                if let Some(i) = n.left.as_ident() {
+                    self.add(i.to_id(), false);
+                    self.add(i.to_id(), true);
+                    n.right.visit_with(self);
+                } else {
+                    n.visit_children_with(self);
+                }
+            }
+        }
+    }
+
+    fn visit_jsx_element_name(&mut self, e: &JSXElementName) {
+        e.visit_children_with(self);
+
+        if let JSXElementName::Ident(i) = e {
+            self.add(i.to_id(), false);
+        }
+    }
+
+    fn visit_jsx_object(&mut self, e: &JSXObject) {
+        e.visit_children_with(self);
+
+        if let JSXObject::Ident(i) = e {
+            self.add(i.to_id(), false);
+        }
+    }
+
+    fn visit_arrow_expr(&mut self, n: &ArrowExpr) {
+        self.with_scope(ScopeKind::ArrowFn, |v| {
+            n.visit_children_with(v);
+
+            if v.scope.found_direct_eval {
+                v.scope.bindings_affected_by_eval = collect_decls(n);
+            }
+        })
+    }
+
+    fn visit_function(&mut self, n: &Function) {
+        self.with_scope(ScopeKind::Fn, |v| {
+            n.visit_children_with(v);
+
+            if v.scope.found_direct_eval {
+                v.scope.bindings_affected_by_eval = collect_decls(n);
+            }
+
+            if v.scope.found_arguemnts {
+                v.scope.bindings_affected_by_arguements = find_pat_ids(&n.params);
+            }
+        })
+    }
+
+    fn visit_fn_decl(&mut self, n: &FnDecl) {
+        self.with_ast_path(vec![n.ident.to_id()], |v| {
+            let old = v.cur_fn_id.take();
+            v.cur_fn_id = Some(n.ident.to_id());
+            n.visit_children_with(v);
+            v.cur_fn_id = old;
+
+            if !n.function.decorators.is_empty() {
+                v.add(n.ident.to_id(), false);
+            }
+        })
+    }
+
+    fn visit_fn_expr(&mut self, n: &FnExpr) {
+        n.visit_children_with(self);
+
+        if !n.function.decorators.is_empty() {
+            if let Some(i) = &n.ident {
+                self.add(i.to_id(), false);
+            }
+        }
+    }
+
+    fn visit_pat(&mut self, p: &Pat) {
+        p.visit_children_with(self);
+
+        if !self.in_var_decl {
+            if let Pat::Ident(i) = p {
+                self.add(i.to_id(), true);
+            }
+        }
+    }
+
+    fn visit_prop(&mut self, p: &Prop) {
+        p.visit_children_with(self);
+
+        if let Prop::Shorthand(i) = p {
+            self.add(i.to_id(), false);
+        }
+    }
+
+    fn visit_var_declarator(&mut self, n: &VarDeclarator) {
+        let old = self.in_var_decl;
+
+        self.in_var_decl = true;
+        n.name.visit_with(self);
+
+        self.in_var_decl = false;
+        n.init.visit_with(self);
+
+        self.in_var_decl = old;
+    }
+}
+
+impl Repeated for TreeShaker {
+    fn changed(&self) -> bool {
+        self.changed
+    }
+
+    fn reset(&mut self) {
+        self.pass += 1;
+        self.changed = false;
+    }
+}
+
+impl TreeShaker {
+    fn visit_mut_stmt_likes<T>(&mut self, stmts: &mut Vec<T>)
+    where
+        T: StmtLike + ModuleItemLike + VisitMutWith<Self> + Send + Sync,
+        Vec<T>: VisitMutWith<Self>,
+    {
+        if let Some(Stmt::Expr(ExprStmt { expr, .. })) = stmts.first().and_then(|s| s.as_stmt()) {
+            if let Expr::Lit(Lit::Str(v)) = &**expr {
+                if &*v.value == "use asm" {
+                    return;
+                }
+            }
+        }
+
+        self.visit_mut_par(cpu_count() * 8, stmts);
+
+        stmts.retain(|s| match s.as_stmt() {
+            Some(Stmt::Empty(..)) => false,
+            Some(Stmt::Block(s)) if s.is_empty() => {
+                debug!("Dropping an empty block statement");
+                false
+            }
+            _ => true,
+        });
+    }
+
+    fn can_drop_binding(&self, name: Id, is_var: bool) -> bool {
+        if !self.config.top_level {
+            if is_var {
+                if !self.in_fn {
+                    return false;
+                }
+            } else if !self.in_block_stmt {
+                return false;
+            }
+        }
+
+        if self.config.top_retain.contains(&name.0) {
+            return false;
+        }
+
+        match self.data.used_names.get(&name) {
+            Some(v) => v.usage == 0 && v.assign == 0,
+            None => true,
+        }
+    }
+
+    fn can_drop_assignment_to(&self, name: Id, is_var: bool) -> bool {
+        if !self.config.top_level {
+            if is_var {
+                if !self.in_fn {
+                    return false;
+                }
+            } else if !self.in_block_stmt {
+                return false;
+            }
+
+            // Abort if the variable is declared on top level scope.
+            let ix = self.data.graph_ix.get_index_of(&name);
+            if let Some(ix) = ix {
+                if self.data.entries.contains(&(ix as u32)) {
+                    return false;
+                }
+            }
+        }
+
+        if self.config.top_retain.contains(&name.0) {
+            return false;
+        }
+
+        // If the name is unresolved, it should be preserved
+        self.expr_ctx.unresolved_ctxt != name.1
+            && self
+                .data
+                .used_names
+                .get(&name)
+                .map(|v| v.usage == 0)
+                .unwrap_or_default()
+    }
+
+    /// Drops RHS from `null && foo`
+    fn optimize_bin_expr(&mut self, n: &mut Expr) {
+        let Expr::Bin(b) = n else {
+            return;
+        };
+
+        if b.op == op!("&&") && b.left.as_pure_bool(self.expr_ctx) == Known(false) {
+            self.data.drop_ast_node(&b.right);
+            *n = *b.left.take();
+            self.changed = true;
+            return;
+        }
+
+        if b.op == op!("||") && b.left.as_pure_bool(self.expr_ctx) == Known(true) {
+            self.data.drop_ast_node(&b.right);
+            *n = *b.left.take();
+            self.changed = true;
+        }
+    }
+
+    fn visit_mut_par<N>(&mut self, _threshold: usize, nodes: &mut [N])
+    where
+        N: Send + Sync + VisitMutWith<Self>,
+    {
+        for n in nodes {
+            n.visit_mut_with(self);
+        }
+    }
+}
+
+impl VisitMut for TreeShaker {
+    noop_visit_mut_type!();
+
+    fn visit_mut_assign_expr(&mut self, n: &mut AssignExpr) {
+        n.visit_mut_children_with(self);
+
+        if let Some(id) = n.left.as_ident() {
+            // TODO: `var`
+            if self.can_drop_assignment_to(id.to_id(), false)
+                && !n.right.may_have_side_effects(self.expr_ctx)
+            {
+                self.changed = true;
+                debug!("Dropping an assignment to `{}` because it's not used", id);
+                self.data.drop_ast_node(&n.left);
+
+                n.left.take();
+            }
+        }
+    }
+
+    fn visit_mut_block_stmt(&mut self, n: &mut BlockStmt) {
+        let old_in_block_stmt = self.in_block_stmt;
+        self.in_block_stmt = true;
+        n.visit_mut_children_with(self);
+        self.in_block_stmt = old_in_block_stmt;
+    }
+
+    fn visit_mut_class_members(&mut self, members: &mut Vec<ClassMember>) {
+        self.visit_mut_par(cpu_count() * 8, members);
+    }
+
+    fn visit_mut_decl(&mut self, n: &mut Decl) {
+        n.visit_mut_children_with(self);
+
+        match n {
+            Decl::Fn(f) => {
+                if self.can_drop_binding(f.ident.to_id(), true) {
+                    debug!("Dropping function `{}` as it's not used", f.ident);
+                    self.changed = true;
+
+                    self.data.drop_ast_node(&*f);
+
+                    n.take();
+                }
+            }
+            Decl::Class(c) => {
+                if self.can_drop_binding(c.ident.to_id(), false)
+                    && c.class
+                        .super_class
+                        .as_deref()
+                        .map_or(true, |e| !e.may_have_side_effects(self.expr_ctx))
+                    && c.class.body.iter().all(|m| match m {
+                        ClassMember::Method(m) => !matches!(m.key, PropName::Computed(..)),
+                        ClassMember::ClassProp(m) => {
+                            !matches!(m.key, PropName::Computed(..))
+                                && !m
+                                    .value
+                                    .as_deref()
+                                    .is_some_and(|e| e.may_have_side_effects(self.expr_ctx))
+                        }
+                        ClassMember::AutoAccessor(m) => {
+                            !matches!(m.key, Key::Public(PropName::Computed(..)))
+                                && !m
+                                    .value
+                                    .as_deref()
+                                    .is_some_and(|e| e.may_have_side_effects(self.expr_ctx))
+                        }
+
+                        ClassMember::PrivateProp(m) => !m
+                            .value
+                            .as_deref()
+                            .is_some_and(|e| e.may_have_side_effects(self.expr_ctx)),
+
+                        ClassMember::StaticBlock(_) => false,
+
+                        ClassMember::TsIndexSignature(_)
+                        | ClassMember::Empty(_)
+                        | ClassMember::Constructor(_)
+                        | ClassMember::PrivateMethod(_) => true,
+                    })
+                {
+                    debug!("Dropping class `{}` as it's not used", c.ident);
+                    self.changed = true;
+
+                    self.data.drop_ast_node(&*c);
+                    n.take();
+                }
+            }
+            _ => {}
+        }
+    }
+
+    fn visit_mut_export_decl(&mut self, n: &mut ExportDecl) {
+        match &mut n.decl {
+            Decl::Var(v) => {
+                for decl in v.decls.iter_mut() {
+                    decl.init.visit_mut_with(self);
+                }
+            }
+            _ => {
+                // Bypass visit_mut_decl
+                n.decl.visit_mut_children_with(self);
+            }
+        }
+    }
+
+    /// Noop.
+    fn visit_mut_export_default_decl(&mut self, _: &mut ExportDefaultDecl) {}
+
+    fn visit_mut_expr(&mut self, n: &mut Expr) {
+        n.visit_mut_children_with(self);
+
+        self.optimize_bin_expr(n);
+
+        if let Expr::Call(CallExpr {
+            callee: Callee::Expr(callee),
+            args,
+            ..
+        }) = n
+        {
+            //
+            if args.is_empty() {
+                match &mut **callee {
+                    Expr::Fn(FnExpr {
+                        ident: None,
+                        function: f,
+                    }) if matches!(&**f, Function {
+                        is_async: false,
+                        is_generator: false,
+                        body: Some(..),
+                        ..
+                    }) =>
+                    {
+                        if f.params.is_empty() && f.body.as_ref().unwrap().stmts.len() == 1 {
+                            if let Stmt::Return(ReturnStmt { arg: Some(arg), .. }) =
+                                &mut f.body.as_mut().unwrap().stmts[0]
+                            {
+                                if let Expr::Object(ObjectLit { props, .. }) = &**arg {
+                                    if props.iter().all(|p| match p {
+                                        PropOrSpread::Spread(_) => false,
+                                        PropOrSpread::Prop(p) => match &**p {
+                                            Prop::Shorthand(_) => true,
+                                            Prop::KeyValue(p) => p.value.is_ident(),
+                                            _ => false,
+                                        },
+                                    }) {
+                                        self.changed = true;
+                                        debug!("Dropping a wrapped esm");
+                                        *n = *arg.take();
+                                        return;
+                                    }
+                                }
+                            }
+                        }
+                    }
+                    _ => (),
+                }
+            }
+        }
+
+        if let Expr::Assign(a) = n {
+            if match &a.left {
+                AssignTarget::Simple(l) => l.is_invalid(),
+                AssignTarget::Pat(l) => l.is_invalid(),
+            } {
+                *n = *a.right.take();
+            }
+        }
+    }
+
+    fn visit_mut_expr_or_spreads(&mut self, n: &mut Vec<ExprOrSpread>) {
+        self.visit_mut_par(cpu_count() * 8, n);
+    }
+
+    fn visit_mut_exprs(&mut self, n: &mut Vec<Box<Expr>>) {
+        self.visit_mut_par(cpu_count() * 8, n);
+    }
+
+    fn visit_mut_for_head(&mut self, n: &mut ForHead) {
+        match n {
+            ForHead::VarDecl(..) | ForHead::UsingDecl(..) => {}
+            ForHead::Pat(v) => {
+                v.visit_mut_with(self);
+            }
+        }
+    }
+
+    fn visit_mut_function(&mut self, n: &mut Function) {
+        let old_in_fn = self.in_fn;
+        self.in_fn = true;
+        n.visit_mut_children_with(self);
+        self.in_fn = old_in_fn;
+    }
+
+    fn visit_mut_import_specifiers(&mut self, ss: &mut Vec<ImportSpecifier>) {
+        ss.retain(|s| {
+            let local = match s {
+                ImportSpecifier::Named(l) => &l.local,
+                ImportSpecifier::Default(l) => &l.local,
+                ImportSpecifier::Namespace(l) => &l.local,
+            };
+
+            if self.can_drop_binding(local.to_id(), false) {
+                debug!(
+                    "Dropping import specifier `{}` because it's not used",
+                    local
+                );
+                self.changed = true;
+                return false;
+            }
+
+            true
+        });
+    }
+
+    fn visit_mut_module(&mut self, m: &mut Module) {
+        let _tracing = span!(Level::ERROR, "tree-shaker", pass = self.pass).entered();
+
+        if !self.data.initialized {
+            let mut data = Data {
+                initialized: true,
+                ..Default::default()
+            };
+
+            {
+                let mut analyzer = Analyzer {
+                    config: &self.config,
+                    in_var_decl: false,
+                    scope: Default::default(),
+                    data: &mut data,
+                    cur_class_id: Default::default(),
+                    cur_fn_id: Default::default(),
+                };
+                m.visit_with(&mut analyzer);
+            }
+            data.subtract_cycles();
+            self.data = data;
+        } else {
+            self.data.subtract_cycles();
+        }
+
+        m.visit_mut_children_with(self);
+    }
+
+    fn visit_mut_module_item(&mut self, n: &mut ModuleItem) {
+        match n {
+            ModuleItem::ModuleDecl(ModuleDecl::Import(i)) => {
+                let is_for_side_effect = i.specifiers.is_empty();
+
+                i.visit_mut_with(self);
+
+                if !self.config.preserve_imports_with_side_effects
+                    && !is_for_side_effect
+                    && i.specifiers.is_empty()
+                {
+                    debug!("Dropping an import because it's not used");
+                    self.changed = true;
+                    *n = EmptyStmt { span: DUMMY_SP }.into();
+                }
+            }
+            _ => {
+                n.visit_mut_children_with(self);
+            }
+        }
+    }
+
+    fn visit_mut_module_items(&mut self, s: &mut Vec<ModuleItem>) {
+        self.visit_mut_stmt_likes(s);
+    }
+
+    fn visit_mut_opt_vec_expr_or_spreads(&mut self, n: &mut Vec<Option<ExprOrSpread>>) {
+        self.visit_mut_par(cpu_count() * 8, n);
+    }
+
+    fn visit_mut_prop_or_spreads(&mut self, n: &mut Vec<PropOrSpread>) {
+        self.visit_mut_par(cpu_count() * 8, n);
+    }
+
+    fn visit_mut_script(&mut self, m: &mut Script) {
+        let _tracing = span!(Level::ERROR, "tree-shaker", pass = self.pass).entered();
+
+        if !self.data.initialized {
+            let mut data = Data {
+                initialized: true,
+                ..Default::default()
+            };
+
+            {
+                let mut analyzer = Analyzer {
+                    config: &self.config,
+                    in_var_decl: false,
+                    scope: Default::default(),
+                    data: &mut data,
+                    cur_class_id: Default::default(),
+                    cur_fn_id: Default::default(),
+                };
+                m.visit_with(&mut analyzer);
+            }
+            data.subtract_cycles();
+            self.data = data;
+        } else {
+            self.data.subtract_cycles();
+        }
+
+        m.visit_mut_children_with(self);
+    }
+
+    fn visit_mut_stmt(&mut self, s: &mut Stmt) {
+        s.visit_mut_children_with(self);
+
+        if let Stmt::Decl(Decl::Var(v)) = s {
+            if v.decls.is_empty() {
+                s.take();
+                return;
+            }
+        }
+
+        if let Stmt::Decl(Decl::Var(v)) = s {
+            let span = v.span;
+            let cnt = v.decls.len();
+
+            // If all name is droppable, do so.
+            if cnt != 0
+                && v.decls.iter().all(|vd| match &vd.name {
+                    Pat::Ident(i) => self.can_drop_binding(i.to_id(), v.kind == VarDeclKind::Var),
+                    _ => false,
+                })
+            {
+                for decl in v.decls.iter() {
+                    self.data.drop_ast_node(&decl.name);
+                }
+
+                let exprs = v
+                    .decls
+                    .take()
+                    .into_iter()
+                    .filter_map(|v| v.init)
+                    .collect::<Vec<_>>();
+
+                debug!(
+                    count = cnt,
+                    "Dropping names of variables as they are not used",
+                );
+                self.changed = true;
+
+                if exprs.is_empty() {
+                    *s = EmptyStmt { span: DUMMY_SP }.into();
+                    return;
+                } else {
+                    *s = ExprStmt {
+                        span,
+                        expr: Expr::from_exprs(exprs),
+                    }
+                    .into();
+                }
+            }
+        }
+
+        if let Stmt::Decl(Decl::Var(v)) = s {
+            if v.decls.is_empty() {
+                *s = EmptyStmt { span: DUMMY_SP }.into();
+            }
+        }
+    }
+
+    fn visit_mut_stmts(&mut self, s: &mut Vec<Stmt>) {
+        self.visit_mut_stmt_likes(s);
+    }
+
+    fn visit_mut_unary_expr(&mut self, n: &mut UnaryExpr) {
+        if matches!(n.op, op!("delete")) {
+            return;
+        }
+        n.visit_mut_children_with(self);
+    }
+
+    fn visit_mut_using_decl(&mut self, n: &mut UsingDecl) {
+        for decl in n.decls.iter_mut() {
+            decl.init.visit_mut_with(self);
+        }
+    }
+
+    fn visit_mut_var_decl(&mut self, n: &mut VarDecl) {
+        let old_var_decl_kind = self.var_decl_kind;
+        self.var_decl_kind = Some(n.kind);
+        n.visit_mut_children_with(self);
+        self.var_decl_kind = old_var_decl_kind;
+    }
+
+    fn visit_mut_var_decl_or_expr(&mut self, n: &mut VarDeclOrExpr) {
+        match n {
+            VarDeclOrExpr::VarDecl(..) => {}
+            VarDeclOrExpr::Expr(v) => {
+                v.visit_mut_with(self);
+            }
+        }
+    }
+
+    fn visit_mut_var_declarator(&mut self, v: &mut VarDeclarator) {
+        v.visit_mut_children_with(self);
+
+        if let Pat::Ident(i) = &v.name {
+            let can_drop = if let Some(init) = &v.init {
+                !init.may_have_side_effects(self.expr_ctx)
+            } else {
+                true
+            };
+
+            if can_drop
+                && self.can_drop_binding(i.to_id(), self.var_decl_kind == Some(VarDeclKind::Var))
+            {
+                self.changed = true;
+                debug!("Dropping {} because it's not used", i);
+                self.data.drop_ast_node(&*v);
+                v.name.take();
+            }
+        }
+    }
+
+    fn visit_mut_var_declarators(&mut self, n: &mut Vec<VarDeclarator>) {
+        self.visit_mut_par(cpu_count() * 8, n);
+
+        n.retain(|v| {
+            if v.name.is_invalid() {
+                return false;
+            }
+
+            true
+        });
+    }
+
+    fn visit_mut_with_stmt(&mut self, n: &mut WithStmt) {
+        n.obj.visit_mut_with(self);
+    }
+}
+
+impl Scope<'_> {
+    /// Returns true if it's not in a function or class.
+    fn is_ast_path_empty(&self) -> bool {
+        if !self.ast_path.is_empty() {
+            return false;
+        }
+        match &self.parent {
+            Some(p) => p.is_ast_path_empty(),
+            None => true,
+        }
+    }
+}

--- a/crates/swc_macro_wasm/src/lib.rs
+++ b/crates/swc_macro_wasm/src/lib.rs
@@ -1,5 +1,6 @@
 use wasm_bindgen::prelude::*;
 
+mod dce;
 pub mod optimize;
 
 #[wasm_bindgen]

--- a/crates/swc_macro_wasm/src/lib.rs
+++ b/crates/swc_macro_wasm/src/lib.rs
@@ -9,3 +9,135 @@ pub fn optimize(source: String, config: &str) -> String {
         serde_json::from_str(config).expect("invalid config: must be a json object");
     optimize::optimize(source, config)
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn test_webpack_tree_shaking_integration() {
+        // Test with a realistic webpack bundle similar to our test cases
+        let source = r#"
+(()=>{
+    "use strict";
+    var __webpack_modules__ = {
+        100: function(__unused_webpack_module, __webpack_exports__, __webpack_require__) {
+            console.log("Entry module");
+            __webpack_require__(200);
+        },
+        200: function(__unused_webpack_module, __webpack_exports__, __webpack_require__) {
+            console.log("Used dependency");
+        },
+        300: function(__unused_webpack_module, __webpack_exports__, __webpack_require__) {
+            console.log("Unused module - should be tree shaken");
+        }
+    };
+    
+    function __webpack_require__(moduleId) {
+        // webpack runtime
+        return {};
+    }
+    
+    (()=>{
+        /* @common:if [condition="features.enableWebpackEntry"] */
+        __webpack_require__(100);
+        /* @common:endif */
+    })();
+})();
+"#.to_string();
+
+        let config = json!({
+            "features": {
+                "enableWebpackEntry": false  // This will remove the entry point call
+            }
+        });
+        let original_size = source.len();
+        let source_for_debug = source.clone();
+        let result = optimize::optimize(source, config);
+        
+        println!("=== DEBUG INTEGRATION TEST ===");
+        println!("Original source ({} bytes):\n{}", original_size, source_for_debug);
+        println!("\nOptimized result ({} bytes):\n{}", result.len(), result);
+        println!("\nSearching for patterns:");
+        println!("  Contains '100:': {}", result.contains("100:"));
+        println!("  Contains '200:': {}", result.contains("200:"));
+        println!("  Contains '300:': {}", result.contains("300:"));
+        println!("  Contains empty webpack_modules: {}", result.contains("var __webpack_modules__ = {};"));
+        
+        // Since the entry point is removed by DCE, tree shaking should remove all modules
+        assert!(!result.contains("100:"), "Module 100 should be tree shaken");
+        assert!(!result.contains("200:"), "Module 200 should be tree shaken");
+        assert!(!result.contains("300:"), "Module 300 should be tree shaken");
+        assert!(!result.contains("__webpack_modules__"), "webpack_modules should be completely removed when no entry points");
+        
+        println!("Tree shaking integration test passed!");
+        println!("Result size: {} bytes (tree shaking saved {} bytes)", 
+                result.len(), 
+                original_size - result.len());
+    }
+
+    #[test]
+    fn test_webpack_tree_shaking_with_macro_conditions() {
+        // Test with a realistic webpack bundle with conditional features
+        let source = r#"
+(()=>{
+    "use strict";
+    var __webpack_modules__ = {
+        100: function(__unused_webpack_module, __webpack_exports__, __webpack_require__) {
+            console.log("Entry module");
+            /* @common:if [condition="features.enableFeatureA"] */
+            __webpack_require__(200);
+            /* @common:endif */
+            /* @common:if [condition="features.enableFeatureB"] */
+            __webpack_require__(300);
+            /* @common:endif */
+        },
+        200: function(__unused_webpack_module, __webpack_exports__, __webpack_require__) {
+            console.log("Feature A module");
+        },
+        300: function(__unused_webpack_module, __webpack_exports__, __webpack_require__) {
+            console.log("Feature B module");
+        },
+        400: function(__unused_webpack_module, __webpack_exports__, __webpack_require__) {
+            console.log("Completely unused module");
+        }
+    };
+    
+    function __webpack_require__(moduleId) {
+        // webpack runtime
+        return {};
+    }
+    
+    (()=>{
+        /* @common:if [condition="features.enableEntryPoint"] */
+        __webpack_require__(100);
+        /* @common:endif */
+    })();
+})();
+"#.to_string();
+
+        let config = json!({
+            "features": {
+                "enableFeatureA": false,
+                "enableFeatureB": false,
+                "enableEntryPoint": false  // This removes the entry point entirely
+            }
+        });
+        
+        let result = optimize::optimize(source, config);
+        
+        println!("=== DEBUG MACRO CONDITIONS TEST ===");
+        println!("Optimized result:\n{}", result);
+        
+        // All modules should be tree shaken since there are no entry points
+        assert!(!result.contains("100:"), "Entry module should be tree shaken");
+        assert!(!result.contains("200:"), "Feature A module should be tree shaken");
+        assert!(!result.contains("300:"), "Feature B module should be tree shaken");
+        assert!(!result.contains("400:"), "Unused module should be tree shaken");
+        assert!(!result.contains("__webpack_modules__"), "webpack_modules should be completely removed when no entry points");
+        
+        println!("Tree shaking with macro conditions test passed!");
+        println!("All modules successfully tree shaken due to no entry points");
+    }
+}

--- a/crates/swc_macro_wasm/src/optimize.rs
+++ b/crates/swc_macro_wasm/src/optimize.rs
@@ -3,8 +3,8 @@ use swc_common::pass::Repeated;
 use swc_common::sync::Lrc;
 use swc_common::{FileName, Mark, SourceMap};
 use swc_core::ecma::codegen;
-use swc_core::ecma::visit::VisitMutWith;
-use swc_ecma_ast::Program;
+use swc_core::ecma::visit::{VisitMutWith, VisitMut};
+use swc_ecma_ast::{Program, Expr, VarDecl, Pat, ObjectLit, PropOrSpread, Prop, PropName};
 use swc_ecma_codegen::text_writer::WriteJs;
 use swc_ecma_codegen::{Emitter, text_writer};
 use swc_ecma_parser::{EsSyntax, Parser, StringInput, Syntax};
@@ -12,6 +12,8 @@ use swc_ecma_transforms_base::fixer::fixer;
 use swc_ecma_transforms_base::resolver;
 use swc_macro_condition_transform::condition_transform;
 use swc_macro_parser::MacroParser;
+use webpack_graph::{WebpackBundleParser, TreeShaker};
+use rustc_hash::FxHashSet;
 
 pub fn optimize(source: String, config: serde_json::Value) -> String {
     let cm: Lrc<SourceMap> = Default::default();
@@ -47,6 +49,9 @@ pub fn optimize(source: String, config: serde_json::Value) -> String {
 
             perform_dce(&mut program, comments.clone(), unresolved_mark);
 
+            // Tree shake webpack modules after removing unused imports
+            perform_webpack_tree_shaking(&mut program, cm.clone(), &comments);
+
             program.mutate(fixer(Some(&comments)));
 
             program
@@ -58,7 +63,7 @@ pub fn optimize(source: String, config: serde_json::Value) -> String {
         let wr = Box::new(text_writer::JsWriter::new(cm.clone(), "\n", &mut buf, None))
             as Box<dyn WriteJs>;
         let mut emitter = Emitter {
-            cfg: codegen::Config::default().with_minify(true),
+            cfg: codegen::Config::default().with_minify(false),
             comments: Some(&comments),
             cm: cm.clone(),
             wr,
@@ -92,5 +97,129 @@ fn perform_dce(m: &mut Program, comments: SingleThreadedComments, unresolved_mar
         }
 
         visitor.reset();
+    }
+}
+
+/// Performs webpack module tree shaking after DCE
+fn perform_webpack_tree_shaking(program: &mut Program, cm: Lrc<SourceMap>, comments: &SingleThreadedComments) {
+    // Step 1: Emit current AST to string for analysis
+    let current_code = {
+        let mut buf = vec![];
+        let wr = Box::new(text_writer::JsWriter::new(cm.clone(), "\n", &mut buf, None))
+            as Box<dyn WriteJs>;
+        let mut emitter = Emitter {
+            cfg: codegen::Config::default().with_minify(false),
+            comments: Some(comments),
+            cm: cm.clone(),
+            wr,
+        };
+        if emitter.emit_program(program).is_err() {
+            return; // Skip tree shaking if emit fails
+        }
+        drop(emitter);
+        
+        match String::from_utf8(buf) {
+            Ok(code) => code,
+            Err(_) => return, // Skip tree shaking if invalid UTF-8
+        }
+    };
+
+    // Step 2: Parse with webpack_graph to analyze module dependencies
+    let parser = match WebpackBundleParser::new() {
+        Ok(p) => p,
+        Err(_) => return, // Skip tree shaking if parser creation fails
+    };
+
+    let mut graph = match parser.parse_bundle(&current_code) {
+        Ok(g) => g,
+        Err(_) => return, // Skip tree shaking if parsing fails - maybe it's not a webpack bundle
+    };
+
+    // Step 3: Use TreeShaker to identify unreachable modules
+    let unreachable_modules = TreeShaker::new(&mut graph).shake();
+    
+    if !unreachable_modules.is_empty() {
+        println!("Tree shaking: Removing {} unreachable webpack modules: {:?}", 
+                 unreachable_modules.len(), unreachable_modules);
+        
+        // Step 4: Remove unreachable modules from the AST
+        let unreachable_set: FxHashSet<String> = unreachable_modules.into_iter().collect();
+        let mut module_remover = WebpackModuleRemover::new(unreachable_set);
+        program.visit_mut_with(&mut module_remover);
+    }
+}
+
+/// AST visitor that removes specified webpack modules from __webpack_modules__ objects
+struct WebpackModuleRemover {
+    modules_to_remove: FxHashSet<String>,
+}
+
+impl WebpackModuleRemover {
+    fn new(modules_to_remove: FxHashSet<String>) -> Self {
+        Self { modules_to_remove }
+    }
+
+    /// Check if a property key matches a module ID that should be removed
+    fn should_remove_property(&self, prop: &PropOrSpread) -> bool {
+        if let PropOrSpread::Prop(prop) = prop {
+            if let Prop::KeyValue(kv) = prop.as_ref() {
+                let module_id = match &kv.key {
+                    PropName::Num(num) => num.value.to_string().split('.').next().unwrap_or("").to_string(),
+                    PropName::Str(s) => s.value.to_string(),
+                    PropName::Ident(ident) => ident.sym.to_string(),
+                    _ => return false,
+                };
+                return self.modules_to_remove.contains(&module_id);
+            }
+        }
+        false
+    }
+
+    /// Remove modules from object literals in expressions
+    fn remove_modules_from_expr(&mut self, expr: &mut Expr) {
+        match expr {
+            Expr::Object(obj) => {
+                self.remove_modules_from_object(obj);
+            }
+            Expr::Paren(paren) => {
+                if let Expr::Object(obj) = paren.expr.as_mut() {
+                    self.remove_modules_from_object(obj);
+                }
+            }
+            _ => {}
+        }
+    }
+
+    /// Remove specified modules from an object literal
+    fn remove_modules_from_object(&mut self, obj: &mut ObjectLit) {
+        obj.props.retain(|prop| !self.should_remove_property(prop));
+    }
+}
+
+impl VisitMut for WebpackModuleRemover {
+    /// Visit variable declarations to find and modify __webpack_modules__
+    fn visit_mut_var_decl(&mut self, node: &mut VarDecl) {
+        for declarator in &mut node.decls {
+            if let Pat::Ident(ident) = &declarator.name {
+                if ident.sym == "__webpack_modules__" {
+                    if let Some(init) = &mut declarator.init {
+                        self.remove_modules_from_expr(init);
+                    }
+                }
+            }
+        }
+        // Continue visiting children
+        node.visit_mut_children_with(self);
+    }
+
+    /// Visit assignment expressions to find and modify __webpack_modules__
+    fn visit_mut_assign_expr(&mut self, node: &mut swc_ecma_ast::AssignExpr) {
+        if let swc_ecma_ast::AssignTarget::Simple(swc_ecma_ast::SimpleAssignTarget::Ident(ident)) = &node.left {
+            if ident.sym == "__webpack_modules__" {
+                self.remove_modules_from_expr(&mut node.right);
+            }
+        }
+        // Continue visiting children
+        node.visit_mut_children_with(self);
     }
 }

--- a/crates/swc_macro_wasm/src/optimize.rs
+++ b/crates/swc_macro_wasm/src/optimize.rs
@@ -73,8 +73,8 @@ pub fn optimize(source: String, config: serde_json::Value) -> String {
 }
 
 fn perform_dce(m: &mut Program, unresolved_mark: Mark) {
-    let mut visitor = swc_ecma_transforms_optimization::simplify::dce::dce(
-        swc_ecma_transforms_optimization::simplify::dce::Config {
+    let mut visitor = crate::dce::dce(
+        crate::dce::Config {
             module_mark: None,
             top_level: true,
             top_retain: Default::default(),

--- a/crates/swc_macro_wasm/src/optimize.rs
+++ b/crates/swc_macro_wasm/src/optimize.rs
@@ -45,7 +45,7 @@ pub fn optimize(source: String, config: serde_json::Value) -> String {
 
             program.mutate(resolver(unresolved_mark, top_level_mark, false));
 
-            perform_dce(&mut program, unresolved_mark);
+            perform_dce(&mut program, comments.clone(), unresolved_mark);
 
             program.mutate(fixer(Some(&comments)));
 
@@ -72,8 +72,9 @@ pub fn optimize(source: String, config: serde_json::Value) -> String {
     ret
 }
 
-fn perform_dce(m: &mut Program, unresolved_mark: Mark) {
+fn perform_dce(m: &mut Program, comments: SingleThreadedComments, unresolved_mark: Mark) {
     let mut visitor = crate::dce::dce(
+        comments,
         crate::dce::Config {
             module_mark: None,
             top_level: true,

--- a/crates/webpack_graph/src/lib.rs
+++ b/crates/webpack_graph/src/lib.rs
@@ -1,10 +1,12 @@
 pub mod error;
 pub mod graph;
 pub mod parser;
+pub mod tree_shaker;
 
 pub use error::WebpackGraphError;
 pub use graph::{ModuleGraph, ModuleNode};
 pub use parser::WebpackBundleParser;
+pub use tree_shaker::TreeShaker;
 
 /// Result type for webpack graph operations
 pub type Result<T> = std::result::Result<T, WebpackGraphError>;
@@ -295,7 +297,7 @@ __webpack_require__(700);
                     assert!(!graph.modules.is_empty(), "Should find modules in {}", test_name);
                     assert!(!graph.entry_points.is_empty(), "Should find entry points in {}", test_name);
                     
-                    println!("  ✅ {} - Found {} modules, {} entry points", 
+                    println!("  {} - Found {} modules, {} entry points", 
                         test_name, graph.modules.len(), graph.entry_points.len());
                 }
                 Err(e) => {
@@ -342,7 +344,7 @@ var __webpack_modules__ = ({
             let result = parser.parse_bundle(bundle_source);
             
             assert!(result.is_err(), "Should fail for invalid format: {}", test_name);
-            println!("  ✅ {} - Correctly failed with: {:?}", test_name, result.unwrap_err());
+            println!("  {} - Correctly failed with: {:?}", test_name, result.unwrap_err());
         }
     }
 
@@ -520,7 +522,7 @@ var __webpack_modules__ = ({
         assert!(main_chain.contains(&"106".to_string()), "Chain should reach common utils");
         assert!(main_chain.contains(&"108".to_string()), "Chain should reach hash functions");
 
-        println!("✅ Complex dependency graph test passed:");
+        println!("Complex dependency graph test passed:");
         println!("   - {} modules with {} entry points", graph.modules.len(), graph.entry_points.len());
         println!("   - Verified shared dependencies and cross-module relationships");
         println!("   - Confirmed deep dependency chains and leaf node sharing");
@@ -536,20 +538,20 @@ var __webpack_modules__ = ({
         // Check if the files exist first and provide helpful error messages
         if !std::path::Path::new(bundle_path).exists() {
             panic!(
-                "❌ Bundle file not found: {}\n\
-                 📋 To fix this, build the rsbuild project first:\n\
-                 💻 cd examples/rsbuild-project && pnpm install && pnpm build\n\
-                 🔍 This test requires the built bundle to validate our parser against real webpack output.",
+                "Bundle file not found: {}\n\
+                 To fix this, build the rsbuild project first:\n\
+                 cd examples/rsbuild-project && pnpm install && pnpm build\n\
+                 This test requires the built bundle to validate our parser against real webpack output.",
                 bundle_path
             );
         }
 
         if !std::path::Path::new(bundle_stats).exists() {
             panic!(
-                "❌ Stats file not found: {}\n\
-                 📋 To fix this, build the rsbuild project first:\n\
-                 💻 cd examples/rsbuild-project && pnpm install && pnpm build\n\
-                 🔍 This test uses stats.json to validate our parser's accuracy.",
+                "Stats file not found: {}\n\
+                 To fix this, build the rsbuild project first:\n\
+                 cd examples/rsbuild-project && pnpm install && pnpm build\n\
+                 This test uses stats.json to validate our parser's accuracy.",
                 bundle_stats
             );
         }
@@ -561,8 +563,8 @@ var __webpack_modules__ = ({
         let parser = WebpackBundleParser::new().expect("Failed to create parser");
         let parsed_graph = parser.parse_bundle(&bundle_content).expect("Failed to parse real-world bundle");
 
-        println!("📊 Real-world Rsbuild Bundle Analysis:");
-        println!("🔍 PARSED from JS bundle:");
+        println!("Real-world Rsbuild Bundle Analysis:");
+        println!("PARSED from JS bundle:");
         println!("   - Total modules parsed: {}", parsed_graph.modules.len());
         println!("   - Entry points found: {} {:?}", parsed_graph.entry_points.len(), parsed_graph.entry_points);
 
@@ -590,7 +592,7 @@ var __webpack_modules__ = ({
         let stats_modules = stats["modules"].as_array()
             .expect("Stats should contain modules array");
 
-        println!("\n📋 EXPECTED from stats.json:");
+        println!("\nEXPECTED from stats.json:");
         println!("   - Total modules in stats: {}", stats_modules.len());
 
         // Extract expected dependency relationships from stats
@@ -662,7 +664,7 @@ var __webpack_modules__ = ({
             .map(|m| m.dependencies.len())
             .sum();
         
-        println!("\n🔗 DEPENDENCY COMPARISON:");
+        println!("\nDEPENDENCY COMPARISON:");
         println!("   - Parsed total dependency relationships: {}", parsed_total_deps);
         
         assert!(parsed_total_deps > 0, "Should parse some dependency relationships");
@@ -752,15 +754,13 @@ var __webpack_modules__ = ({
             "Real bundle with {} modules should have dependency chains of at least depth {} (found: {})",
             parsed_graph.modules.len(), expected_min_depth, max_depth);
 
-        println!("\n✅ Real-world bundle parsing verification passed:");
+        println!("\nReal-world bundle parsing verification passed:");
         println!("   - Successfully parsed {} modules from JS bundle", parsed_graph.modules.len());
         println!("   - Found {} entry points", parsed_graph.entry_points.len());
         println!("   - Detected {} dependency relationships", parsed_total_deps);
         println!("   - Verified {} common modules with stats ({}%)", common_modules.len(), coverage_percentage);
         println!("   - Confirmed {} shared dependencies ({}%)", shared_deps, sharing_ratio);
-        println!("   - Maximum dependency depth: {} (expected: ≥{})", max_depth, expected_min_depth);
-        println!("   - Parser correctly extracts webpack bundle structure! 🎉");
+        println!("   - Maximum dependency depth: {} (expected: >={})", max_depth, expected_min_depth);
+        println!("   - Parser correctly extracts webpack bundle structure!");
     }
-
-    
 }  

--- a/crates/webpack_graph/src/parser.rs
+++ b/crates/webpack_graph/src/parser.rs
@@ -74,11 +74,8 @@ impl WebpackBundleParser {
             }
         }
 
-        if graph.entry_points.is_empty() {
-            return Err(WebpackGraphError::InvalidBundleFormat(
-                "No entry points found - __webpack_require__ calls must exist outside __webpack_modules__".to_string(),
-            ));
-        }
+        // Note: Empty entry points are allowed for tree shaking scenarios where DCE
+        // has removed all entry point imports, making all modules unreachable
 
         Ok(graph)
     }

--- a/crates/webpack_graph/src/tree_shaker.rs
+++ b/crates/webpack_graph/src/tree_shaker.rs
@@ -1,0 +1,626 @@
+use crate::graph::ModuleGraph;
+
+/// Provides tree-shaking capabilities for a `ModuleGraph`.
+///
+/// This struct holds a mutable reference to a `ModuleGraph` and offers
+/// methods to remove modules and perform tree-shaking to eliminate dead code.
+pub struct TreeShaker<'a> {
+    graph: &'a mut ModuleGraph,
+}
+
+impl<'a> TreeShaker<'a> {
+    /// Creates a new `TreeShaker` instance for the given `ModuleGraph`.
+    pub fn new(graph: &'a mut ModuleGraph) -> Self {
+        Self { graph }
+    }
+
+    /// Removes a module by its ID.
+    ///
+    /// This is a low-level operation that disconnects the module from its
+    /// dependencies and dependents, then removes it from the graph.
+    ///
+    /// Returns `true` if the module was found and removed, `false` otherwise.
+    pub fn remove_module(&mut self, module_id: &str) -> bool {
+        if let Some(removed_module) = self.graph.modules.remove(module_id) {
+            // Disconnect from dependencies: for each module this one depended on,
+            // remove this module from their list of dependents.
+            for dep_id in &removed_module.dependencies {
+                if let Some(dep_module) = self.graph.modules.get_mut(dep_id) {
+                    dep_module.dependents.remove(module_id);
+                }
+            }
+
+            // Disconnect from dependents: for each module that depended on this one,
+            // remove this module from their list of dependencies.
+            for dependent_id in &removed_module.dependents {
+                if let Some(dependent_module) = self.graph.modules.get_mut(dependent_id) {
+                    dependent_module.dependencies.remove(module_id);
+                }
+            }
+
+            // If the removed module was an entry point, remove it from the list.
+            self.graph.entry_points.retain(|id| id != module_id);
+
+            true
+        } else {
+            false
+        }
+    }
+
+    /// Performs tree-shaking by removing all modules that are not reachable
+    /// from the graph's entry points.
+    ///
+    /// This is the primary method for eliminating dead code from the graph.
+    ///
+    /// Returns a `Vec<String>` of the removed module IDs.
+    pub fn shake(&mut self) -> Vec<String> {
+        let unreachable_ids = self.graph.get_unreachable_modules();
+        for module_id in &unreachable_ids {
+            self.remove_module(module_id);
+        }
+        unreachable_ids
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{parser::WebpackBundleParser, Result};
+
+    #[test]
+    fn test_shake_simple_bundle() -> Result<()> {
+        let bundle_content = r#"
+var __webpack_modules__ = ({
+  100: (function (module, exports, __webpack_require__) { // entry
+    var dep = __webpack_require__(200);
+  }),
+  200: (function (module, exports, __webpack_require__) { // dependency
+    console.log("Module 200");
+  }),
+  300: (function (module, exports, __webpack_require__) { // dead code
+    console.log("Module 300 - unreachable");
+  })
+});
+__webpack_require__(100);
+"#;
+        let parser = WebpackBundleParser::new()?;
+        let mut graph = parser.parse_bundle(bundle_content)?;
+
+        assert_eq!(graph.modules.len(), 3);
+        assert!(graph.get_module("300").is_some());
+
+        let shaken_ids = TreeShaker::new(&mut graph).shake();
+
+        assert_eq!(shaken_ids, vec!["300".to_string()]);
+        assert_eq!(graph.modules.len(), 2);
+        assert!(graph.get_module("100").is_some());
+        assert!(graph.get_module("200").is_some());
+        assert!(graph.get_module("300").is_none());
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_shake_dependency_chain_with_dead_branch() -> Result<()> {
+        let bundle_content = r#"
+var __webpack_modules__ = ({
+  1: (function(m,e,__webpack_require__){ __webpack_require__(2); }), // entry
+  2: (function(m,e,__webpack_require__){ __webpack_require__(3); }), // A
+  3: (function(m,e,__webpack_require__){}),       // B (leaf)
+  4: (function(m,e,__webpack_require__){ __webpack_require__(5); }), // C (unreachable branch root)
+  5: (function(m,e,__webpack_require__){})        // D (unreachable leaf)
+});
+__webpack_require__(1);
+"#;
+        let parser = WebpackBundleParser::new()?;
+        let mut graph = parser.parse_bundle(bundle_content)?;
+
+        assert_eq!(graph.modules.len(), 5);
+        let mut unreachable = graph.get_unreachable_modules();
+        unreachable.sort();
+        assert_eq!(unreachable, vec!["4".to_string(), "5".to_string()]);
+
+        let mut shaken_ids = TreeShaker::new(&mut graph).shake();
+        shaken_ids.sort();
+
+        assert_eq!(shaken_ids, vec!["4".to_string(), "5".to_string()]);
+        assert_eq!(graph.modules.len(), 3);
+        assert!(graph.get_module("1").is_some());
+        assert!(graph.get_module("2").is_some());
+        assert!(graph.get_module("3").is_some());
+        assert!(graph.get_module("4").is_none());
+        assert!(graph.get_module("5").is_none());
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_shake_no_unreachable_modules() -> Result<()> {
+        let bundle_content = r#"
+var __webpack_modules__ = ({
+  1: (function(m,e,__webpack_require__){ __webpack_require__(2); __webpack_require__(3); }), // entry
+  2: (function(m,e,__webpack_require__){}),
+  3: (function(m,e,__webpack_require__){})
+});
+__webpack_require__(1);
+"#;
+        let parser = WebpackBundleParser::new()?;
+        let mut graph = parser.parse_bundle(bundle_content)?;
+
+        assert_eq!(graph.modules.len(), 3);
+        assert!(graph.get_unreachable_modules().is_empty());
+
+        let shaken_ids = TreeShaker::new(&mut graph).shake();
+        assert!(shaken_ids.is_empty());
+        assert_eq!(graph.modules.len(), 3);
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_remove_module_and_check_graph_integrity() -> Result<()> {
+        let bundle_content = r#"
+var __webpack_modules__ = ({
+  10: (function(m,e,__webpack_require__){ __webpack_require__(20); __webpack_require__(30); }), // entry
+  20: (function(m,e,__webpack_require__){ __webpack_require__(40); }),      // A -> C
+  30: (function(m,e,__webpack_require__){ __webpack_require__(40); }),      // B -> C
+  40: (function(m,e,__webpack_require__){})              // C (shared)
+});
+__webpack_require__(10);
+"#;
+        let parser = WebpackBundleParser::new()?;
+        let mut graph = parser.parse_bundle(bundle_content)?;
+
+        // Initial state: C (40) is shared by A (20) and B (30)
+        assert_eq!(graph.modules.len(), 4);
+        let module_c = graph.get_module("40").unwrap();
+        assert_eq!(module_c.dependents.len(), 2);
+        assert!(module_c.dependents.contains("20"));
+        assert!(module_c.dependents.contains("30"));
+        
+        // Remove module A (20)
+        let removed = TreeShaker::new(&mut graph).remove_module("20");
+        assert!(removed);
+        assert_eq!(graph.modules.len(), 3);
+        assert!(graph.get_module("20").is_none());
+
+        // Check C's dependents: A should be gone, B should remain
+        let module_c_after_a = graph.get_module("40").unwrap();
+        assert_eq!(module_c_after_a.dependents.len(), 1);
+        assert!(module_c_after_a.dependents.contains("30"));
+
+        // C should still be reachable via B
+        assert!(graph.get_unreachable_modules().is_empty(), "C should still be reachable via B");
+
+        // Now remove module B (30)
+        let removed_b = TreeShaker::new(&mut graph).remove_module("30");
+        assert!(removed_b);
+
+        // Now C (40) should be unreachable
+        let mut unreachable = graph.get_unreachable_modules();
+        unreachable.sort();
+        assert_eq!(unreachable, vec!["40".to_string()]);
+
+        // Shake the graph
+        let mut shaken_ids = TreeShaker::new(&mut graph).shake();
+        shaken_ids.sort();
+        assert_eq!(shaken_ids, vec!["40".to_string()]);
+        assert_eq!(graph.modules.len(), 1);
+        assert!(graph.get_module("10").is_some());
+        assert!(graph.get_module("30").is_none());
+        assert!(graph.get_module("40").is_none());
+        
+        Ok(())
+    }
+
+    #[test]
+    fn test_shake_complex_graph_with_dead_branches() -> Result<()> {
+        let complex_bundle = r#"
+var __webpack_modules__ = ({
+  // === Reachable Modules ===
+  // Entry Points
+  100: (function(m,e,__webpack_require__){ __webpack_require__(300); __webpack_require__(400); }), // main -> shared_utils, feature_A
+  200: (function(m,e,__webpack_require__){ __webpack_require__(300); __webpack_require__(500); }), // admin -> shared_utils, feature_B
+
+  // Shared Libraries
+  300: (function(m,e,__webpack_require__){ __webpack_require__(600); }),      // shared_utils -> common_lib
+  
+  // Features
+  400: (function(m,e,__webpack_require__){ __webpack_require__(600); }),      // feature_A -> common_lib
+  500: (function(m,e,__webpack_require__){ __webpack_require__(600); }),      // feature_B -> common_lib
+
+  // Core library (heavily shared)
+  600: (function(m,e,__webpack_require__){}),              // common_lib (leaf)
+
+  // === Unreachable Modules ===
+  // A dead branch that is internally connected but not called from any entry point
+  700: (function(m,e,__webpack_require__){ __webpack_require__(800); }),      // dead_feature_root -> dead_feature_util
+  800: (function(m,e,__webpack_require__){}),              // dead_feature_util
+
+  // An isolated, completely unused module
+  900: (function(m,e,__webpack_require__){})               // isolated_dead_module
+});
+
+// Bootstrap: Only main and admin are called, making 700, 800, 900 unreachable
+__webpack_require__(100);
+__webpack_require__(200);
+"#;
+
+        let parser = WebpackBundleParser::new()?;
+        let mut graph = parser.parse_bundle(complex_bundle)?;
+
+        // 1. Verify initial state
+        assert_eq!(graph.modules.len(), 9, "Should parse all 9 modules");
+        assert_eq!(graph.entry_points.len(), 2, "Should have 2 entry points");
+
+        // 2. Verify unreachable modules are correctly identified
+        let mut unreachable = graph.get_unreachable_modules();
+        unreachable.sort();
+        assert_eq!(
+            unreachable,
+            vec!["700", "800", "900"],
+            "Should identify the dead branch and the isolated module as unreachable"
+        );
+        
+        // 3. Perform tree-shaking
+        let mut shaken_ids = TreeShaker::new(&mut graph).shake();
+        shaken_ids.sort();
+        
+        // 4. Assert that the correct modules were removed
+        assert_eq!(
+            shaken_ids,
+            vec!["700", "800", "900"],
+            "Should report the correct shaken module IDs"
+        );
+        
+        // 5. Assert the final state of the graph
+        assert_eq!(graph.modules.len(), 6, "Graph should have 6 modules remaining");
+        assert!(graph.get_module("700").is_none());
+        assert!(graph.get_module("800").is_none());
+        assert!(graph.get_module("900").is_none());
+        
+        // 6. Verify integrity of the remaining graph
+        let common_lib = graph.get_module("600").unwrap();
+        assert_eq!(
+            common_lib.dependents.len(), 
+            3, 
+            "common_lib should still have 3 dependents (shared_utils, feature_A, feature_B)"
+        );
+        assert!(common_lib.dependents.contains("300"));
+        assert!(common_lib.dependents.contains("400"));
+        assert!(common_lib.dependents.contains("500"));
+
+        let shared_utils = graph.get_module("300").unwrap();
+        assert_eq!(
+            shared_utils.dependents.len(),
+            2,
+            "shared_utils should have 2 dependents (main, admin)"
+        );
+        assert!(shared_utils.dependents.contains("100"));
+        assert!(shared_utils.dependents.contains("200"));
+        
+        Ok(())
+    }
+
+    #[test]
+    fn test_debug_tree_shaking_process() -> Result<()> {
+        let complex_bundle = r#"
+var __webpack_modules__ = ({
+  // Reachable chain: 100 -> 300 -> 600
+  100: (function(m,e,__webpack_require__){ 
+    console.log("Entry point main");
+    __webpack_require__(300); 
+  }),
+  300: (function(m,e,__webpack_require__){ 
+    console.log("Shared utils");
+    __webpack_require__(600); 
+  }),
+  600: (function(m,e,__webpack_require__){ 
+    console.log("Common lib - leaf");
+  }),
+  
+  // Unreachable chain: 700 -> 800
+  700: (function(m,e,__webpack_require__){ 
+    console.log("Dead feature");
+    __webpack_require__(800); 
+  }),
+  800: (function(m,e,__webpack_require__){ 
+    console.log("Dead utility");
+  }),
+  
+  // Isolated unreachable module
+  900: (function(m,e,__webpack_require__){ 
+    console.log("Isolated dead module");
+  })
+});
+
+__webpack_require__(100);
+"#;
+
+        let parser = WebpackBundleParser::new()?;
+        let mut graph = parser.parse_bundle(complex_bundle)?;
+
+        println!("\n=== TREE SHAKING DEBUG ANALYSIS ===");
+        
+        // 1. Show initial graph state
+        println!("\nINITIAL GRAPH STATE:");
+        println!("   Total modules: {}", graph.modules.len());
+        println!("   Entry points: {:?}", graph.entry_points);
+        
+        println!("\nMODULE DEPENDENCIES:");
+        let mut sorted_modules: Vec<_> = graph.modules.iter().collect();
+        sorted_modules.sort_by_key(|(id, _)| id.parse::<u32>().unwrap_or(999));
+        
+        for (id, module) in &sorted_modules {
+            println!("   Module {}: deps={:?}, dependents={:?}", 
+                id, 
+                module.dependencies.iter().collect::<Vec<_>>(),
+                module.dependents.iter().collect::<Vec<_>>()
+            );
+        }
+        
+        // 2. Show reachability analysis
+        let reachable = graph.get_reachable_modules();
+        let mut unreachable = graph.get_unreachable_modules();
+        unreachable.sort();
+        
+        println!("\nREACHABILITY ANALYSIS:");
+        println!("   Reachable modules: {:?}", {
+            let mut sorted_reachable: Vec<_> = reachable.iter().collect();
+            sorted_reachable.sort();
+            sorted_reachable
+        });
+        println!("   Unreachable modules: {:?}", unreachable);
+        
+        // 3. Perform tree-shaking with step-by-step output
+        println!("\nTREE SHAKING PROCESS:");
+        println!("   Removing {} unreachable modules...", unreachable.len());
+        
+        let mut shaken_ids = TreeShaker::new(&mut graph).shake();
+        shaken_ids.sort();
+        
+        println!("   Removed modules: {:?}", shaken_ids);
+        
+        // 4. Show final graph state
+        println!("\nFINAL GRAPH STATE:");
+        println!("   Remaining modules: {}", graph.modules.len());
+        println!("\nREMAINING MODULE DEPENDENCIES:");
+        let mut final_sorted: Vec<_> = graph.modules.iter().collect();
+        final_sorted.sort_by_key(|(id, _)| id.parse::<u32>().unwrap_or(999));
+        
+        for (id, module) in &final_sorted {
+            println!("   Module {}: deps={:?}, dependents={:?}", 
+                id, 
+                module.dependencies.iter().collect::<Vec<_>>(),
+                module.dependents.iter().collect::<Vec<_>>()
+            );
+        }
+        
+        // 5. Verify integrity
+        println!("\nINTEGRITY VERIFICATION:");
+        let final_reachable = graph.get_reachable_modules();
+        let final_unreachable = graph.get_unreachable_modules();
+        
+        println!("   All remaining modules reachable: {}", final_unreachable.is_empty());
+        println!("   Final reachable count: {}", final_reachable.len());
+        println!("   Final total count: {}", graph.modules.len());
+        
+        // Assertions
+        assert_eq!(shaken_ids, vec!["700", "800", "900"]);
+        assert_eq!(graph.modules.len(), 3);
+        assert!(final_unreachable.is_empty());
+        assert_eq!(final_reachable.len(), 3);
+        
+        println!("\nTree shaking completed successfully!\n");
+        Ok(())
+    }
+
+    #[test]
+    fn test_circular_dependencies() -> Result<()> {
+        let bundle_content = r#"
+var __webpack_modules__ = ({
+  1: (function(m,e,__webpack_require__){ __webpack_require__(2); }), // entry -> A
+  2: (function(m,e,__webpack_require__){ __webpack_require__(3); }), // A -> B  
+  3: (function(m,e,__webpack_require__){ __webpack_require__(2); }), // B -> A (circular)
+  4: (function(m,e,__webpack_require__){})                           // isolated
+});
+__webpack_require__(1);
+"#;
+        let parser = WebpackBundleParser::new()?;
+        let mut graph = parser.parse_bundle(bundle_content)?;
+
+        println!("\n=== CIRCULAR DEPENDENCIES TEST ===");
+        
+        // Show circular relationship
+        assert!(graph.get_module("2").unwrap().dependencies.contains("3"));
+        assert!(graph.get_module("3").unwrap().dependencies.contains("2"));
+        assert!(graph.get_module("2").unwrap().dependents.contains("3"));
+        assert!(graph.get_module("3").unwrap().dependents.contains("2"));
+        
+        // Only module 4 should be unreachable
+        let mut unreachable = graph.get_unreachable_modules();
+        unreachable.sort();
+        assert_eq!(unreachable, vec!["4"]);
+        
+        let shaken_ids = TreeShaker::new(&mut graph).shake();
+        assert_eq!(shaken_ids, vec!["4".to_string()]);
+        assert_eq!(graph.modules.len(), 3); // 1, 2, 3 remain
+        
+        println!("Circular dependencies handled correctly");
+        Ok(())
+    }
+
+    #[test]
+    fn test_entry_point_as_dependency() -> Result<()> {
+        let bundle_content = r#"
+var __webpack_modules__ = ({
+  100: (function(m,e,__webpack_require__){ __webpack_require__(200); }), // entry1 -> shared
+  200: (function(m,e,__webpack_require__){}),                            // shared module (also entry2)
+  300: (function(m,e,__webpack_require__){})                             // isolated
+});
+__webpack_require__(100); // entry1
+__webpack_require__(200); // entry2 (also dependency of entry1)
+"#;
+        let parser = WebpackBundleParser::new()?;
+        let mut graph = parser.parse_bundle(bundle_content)?;
+
+        println!("\n=== ENTRY POINT AS DEPENDENCY TEST ===");
+        
+        // Both 100 and 200 should be entry points
+        assert_eq!(graph.entry_points.len(), 2);
+        assert!(graph.entry_points.contains(&"100".to_string()));
+        assert!(graph.entry_points.contains(&"200".to_string()));
+        
+        // Module 200 should be both entry point and dependency
+        assert!(graph.get_module("100").unwrap().dependencies.contains("200"));
+        assert!(graph.get_module("200").unwrap().dependents.contains("100"));
+        
+        // Only module 300 should be unreachable
+        let unreachable = graph.get_unreachable_modules();
+        assert_eq!(unreachable, vec!["300".to_string()]);
+        
+        let shaken_ids = TreeShaker::new(&mut graph).shake();
+        assert_eq!(shaken_ids, vec!["300".to_string()]);
+        assert_eq!(graph.modules.len(), 2); // 100, 200 remain
+        
+        println!("Entry point as dependency handled correctly");
+        Ok(())
+    }
+
+    #[test]
+    fn test_cascading_tree_shaking() -> Result<()> {
+        let bundle_content = r#"
+var __webpack_modules__ = ({
+  1: (function(m,e,__webpack_require__){ __webpack_require__(2); }),   // entry -> bridge
+  2: (function(m,e,__webpack_require__){ __webpack_require__(3); }),   // bridge -> A
+  3: (function(m,e,__webpack_require__){ __webpack_require__(4); }),   // A -> B  
+  4: (function(m,e,__webpack_require__){ __webpack_require__(5); }),   // B -> C
+  5: (function(m,e,__webpack_require__){}),                            // C (leaf)
+  6: (function(m,e,__webpack_require__){ __webpack_require__(7); }),   // isolated chain start
+  7: (function(m,e,__webpack_require__){})                             // isolated chain end
+});
+__webpack_require__(1);
+"#;
+        let parser = WebpackBundleParser::new()?;
+        let mut graph = parser.parse_bundle(bundle_content)?;
+
+        println!("\n=== CASCADING TREE SHAKING TEST ===");
+        
+        // Initially, 6 and 7 should be unreachable
+        let mut unreachable = graph.get_unreachable_modules();
+        unreachable.sort();
+        assert_eq!(unreachable, vec!["6", "7"]);
+        
+        // Remove bridge module 2 manually - this should make 3,4,5 unreachable too
+        TreeShaker::new(&mut graph).remove_module("2");
+        
+        // Now 3,4,5,6,7 should be unreachable (cascading effect)
+        let mut new_unreachable = graph.get_unreachable_modules();
+        new_unreachable.sort();
+        assert_eq!(new_unreachable, vec!["3", "4", "5", "6", "7"]);
+        
+        // Shake remaining dead code
+        let mut final_shaken = TreeShaker::new(&mut graph).shake();
+        final_shaken.sort();
+        assert_eq!(final_shaken, vec!["3", "4", "5", "6", "7"]);
+        assert_eq!(graph.modules.len(), 1); // Only entry module 1 remains
+        
+        println!("Cascading tree shaking works correctly");
+        Ok(())
+    }
+
+    #[test]
+    fn test_diamond_dependency_pattern() -> Result<()> {
+        let bundle_content = r#"
+var __webpack_modules__ = ({
+  1: (function(m,e,__webpack_require__){ 
+    __webpack_require__(2); 
+    __webpack_require__(3); 
+  }),                                                                   // entry -> B, C
+  2: (function(m,e,__webpack_require__){ __webpack_require__(4); }),   // B -> D
+  3: (function(m,e,__webpack_require__){ __webpack_require__(4); }),   // C -> D  
+  4: (function(m,e,__webpack_require__){}),                            // D (shared leaf)
+  5: (function(m,e,__webpack_require__){})                             // isolated
+});
+__webpack_require__(1);
+"#;
+        let parser = WebpackBundleParser::new()?;
+        let mut graph = parser.parse_bundle(bundle_content)?;
+
+        println!("\n=== DIAMOND DEPENDENCY PATTERN TEST ===");
+        
+        // Module 4 should have 2 dependents (B and C)
+        let module_d = graph.get_module("4").unwrap();
+        assert_eq!(module_d.dependents.len(), 2);
+        assert!(module_d.dependents.contains("2"));
+        assert!(module_d.dependents.contains("3"));
+        
+        // Only module 5 should be unreachable
+        let unreachable = graph.get_unreachable_modules();
+        assert_eq!(unreachable, vec!["5".to_string()]);
+        
+        // Test removing one branch of the diamond
+        TreeShaker::new(&mut graph).remove_module("2");
+        
+        // Module 4 should still be reachable via module 3
+        assert!(graph.get_unreachable_modules().is_empty() || graph.get_unreachable_modules() == vec!["5".to_string()]);
+        
+        // Now remove the other branch
+        TreeShaker::new(&mut graph).remove_module("3");
+        
+        // Now module 4 should become unreachable
+        let mut new_unreachable = graph.get_unreachable_modules();
+        new_unreachable.sort();
+        assert_eq!(new_unreachable, vec!["4", "5"]);
+        
+        println!("Diamond dependency pattern handled correctly");
+        Ok(())
+    }
+
+    #[test]
+    fn test_deep_dependency_chain() -> Result<()> {
+        let bundle_content = r#"
+var __webpack_modules__ = ({
+  1: (function(m,e,__webpack_require__){ __webpack_require__(2); }),
+  2: (function(m,e,__webpack_require__){ __webpack_require__(3); }),  
+  3: (function(m,e,__webpack_require__){ __webpack_require__(4); }),
+  4: (function(m,e,__webpack_require__){ __webpack_require__(5); }),
+  5: (function(m,e,__webpack_require__){ __webpack_require__(6); }),
+  6: (function(m,e,__webpack_require__){ __webpack_require__(7); }),
+  7: (function(m,e,__webpack_require__){ __webpack_require__(8); }),
+  8: (function(m,e,__webpack_require__){}),                          // deep leaf
+  9: (function(m,e,__webpack_require__){})                           // isolated
+});
+__webpack_require__(1);
+"#;
+        let parser = WebpackBundleParser::new()?;
+        let mut graph = parser.parse_bundle(bundle_content)?;
+
+        println!("\n=== DEEP DEPENDENCY CHAIN TEST ===");
+        
+        // Verify the chain is correctly built
+        let dependency_chain = graph.get_dependency_chain("1");
+        assert!(dependency_chain.len() >= 8); // Should include all modules in chain
+        
+        // Only module 9 should be unreachable
+        let unreachable = graph.get_unreachable_modules();
+        assert_eq!(unreachable, vec!["9".to_string()]);
+        
+        // Break the chain at module 4
+        TreeShaker::new(&mut graph).remove_module("4");
+        
+        // Modules 5,6,7,8,9 should now be unreachable
+        let mut new_unreachable = graph.get_unreachable_modules();
+        new_unreachable.sort();
+        assert_eq!(new_unreachable, vec!["5", "6", "7", "8", "9"]);
+        
+        // Shake remaining dead code
+        let mut shaken = TreeShaker::new(&mut graph).shake();
+        shaken.sort();
+        assert_eq!(shaken, vec!["5", "6", "7", "8", "9"]);
+        assert_eq!(graph.modules.len(), 3); // 1,2,3 remain
+        
+        println!("Deep dependency chain handled correctly");
+        Ok(())
+    }
+} 

--- a/test-cases/simple-code/jsx-conditional-rendering.js
+++ b/test-cases/simple-code/jsx-conditional-rendering.js
@@ -1,67 +1,50 @@
 const React = require('react');
 
 function ComplexAppRouter({ userType = "free", platform = "desktop", deviceCapabilities = {}, abTestVariant = "grid" }) {
-  const isMobile = platform === "mobile";
-  const isDesktop = platform === "desktop";
-  const isTablet = platform === "tablet";
   
-  // Simulate feature flags from App.tsx
-  const hasAdvancedAnalytics = userType === "premium" || userType === "enterprise";
-  const hasCollaboration = userType === "enterprise";
-  const hasMobileCamera = isMobile && deviceCapabilities.camera;
-  const hasDesktopShortcuts = isDesktop;
-  const has3DVisualization = hasAdvancedAnalytics;
-  const hasNotifications = true;
-  const isAdmin = userType === "admin";
-  
-  // Navigation component
-  const Navigation = () => (
-    <nav style={{ 
-      padding: '10px', 
-      backgroundColor: '#f8f9fa', 
-      borderBottom: '1px solid #dee2e6',
-      marginBottom: '20px' 
-    }}>
-      <h2 style={{ margin: '0 0 10px 0', color: '#495057' }}>
-        SWC Demo - Complex Conditional Routing
-      </h2>
-      {/* @common:if [condition="platform.isMobile"] */}
-      {isMobile ? (
+  return (
+    <div style={{ maxWidth: '800px', margin: '0 auto', padding: '20px', fontFamily: 'Arial, sans-serif' }}>
+      
+      {/* Navigation component */}
+      <nav style={{ 
+        padding: '10px', 
+        backgroundColor: '#f8f9fa', 
+        borderBottom: '1px solid #dee2e6',
+        marginBottom: '20px' 
+      }}>
+        <h2 style={{ margin: '0 0 10px 0', color: '#495057' }}>
+          SWC Demo - Complex Conditional Routing
+        </h2>
+        
+        {/* @common:if [condition="platform.isMobile"] */}
         <div style={{ fontSize: '14px', color: '#6c757d' }}>
           📱 Mobile Interface Active
           {/* @common:if [condition="platform.hasVibration"] */}
-          {deviceCapabilities.vibration && (
-            <span style={{ marginLeft: '10px', color: '#28a745' }}>
-              ✨ Haptic feedback available
-            </span>
-          )}
+          <span style={{ marginLeft: '10px', color: '#28a745' }}>
+            ✨ Haptic feedback available
+          </span>
           {/* @common:endif */}
         </div>
-      ) : (
+        {/* @common:endif */}
+        
+        {/* @common:if [condition="platform.isDesktop"] */}
         <div style={{ fontSize: '14px', color: '#6c757d' }}>
-          <>🖥️ Desktop Interface Active</>
-          {/* @common:if [condition="platform.isDesktop"] */}
-          {isDesktop && (
-            <span style={{ marginLeft: '10px', color: '#007bff' }}>
-              ⌨️ Keyboard shortcuts enabled
-            </span>
-          )} 
+          🖥️ Desktop Interface Active
+          {/* @common:if [condition="featureFlags.hasDesktopShortcuts"] */}
+          <span style={{ marginLeft: '10px', color: '#007bff' }}>
+            ⌨️ Keyboard shortcuts enabled
+          </span>
           {/* @common:endif */}
         </div>
-      )}
-      {/* @common:endif */}
-    </nav>
-  );
+        {/* @common:endif */}
+      </nav>
 
-  // Dashboard Layout based on A/B test variant
-  const DashboardContent = () => (
-    <div style={{ padding: '15px', border: '1px solid #e9ecef', borderRadius: '8px', marginBottom: '20px' }}>
-      <h3 style={{ color: '#343a40', marginBottom: '15px' }}>
-        Dashboard ({abTestVariant} layout)
-      </h3>
-      
-      {/* @common:if [condition="abTests.dashboardLayout === 'grid'"] */}
-      {abTestVariant === "grid" ? (
+      {/* Dashboard Layout - Grid Version */}
+      {/* @common:if [condition="abTests.isGridLayout"] */}
+      <div style={{ padding: '15px', border: '1px solid #e9ecef', borderRadius: '8px', marginBottom: '20px' }}>
+        <h3 style={{ color: '#343a40', marginBottom: '15px' }}>
+          Dashboard (grid layout)
+        </h3>
         <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(200px, 1fr))', gap: '15px' }}>
           <div style={{ padding: '10px', backgroundColor: '#e3f2fd', borderRadius: '6px' }}>
             <strong>Grid Item 1</strong>
@@ -71,24 +54,27 @@ function ComplexAppRouter({ userType = "free", platform = "desktop", deviceCapab
             <strong>Grid Item 2</strong>
             <p style={{ fontSize: '12px', margin: '5px 0' }}>Optimized for desktop</p>
           </div>
-          {/* @common:if [condition="featureFlags.advanced-analytics"] */}
-          {hasAdvancedAnalytics && (
-            <div style={{ padding: '10px', backgroundColor: '#e8f5e8', borderRadius: '6px' }}>
-              <strong>Analytics Panel</strong>
-              <p style={{ fontSize: '12px', margin: '5px 0' }}>Premium analytics enabled</p>
-              {/* @common:if [condition="featureFlags.3d-visualization"] */}
-              {has3DVisualization && (
-                <div style={{ marginTop: '8px', fontSize: '11px', color: '#28a745' }}>
-                  🎯 3D visualization ready
-                </div>
-              )}
-              {/* @common:endif */}
+          {/* @common:if [condition="featureFlags.hasAdvancedAnalytics"] */}
+          <div style={{ padding: '10px', backgroundColor: '#e8f5e8', borderRadius: '6px' }}>
+            <strong>Analytics Panel</strong>
+            <p style={{ fontSize: '12px', margin: '5px 0' }}>Premium analytics enabled</p>
+            {/* @common:if [condition="featureFlags.has3dVisualization"] */}
+            <div style={{ marginTop: '8px', fontSize: '11px', color: '#28a745' }}>
+              🎯 3D visualization ready
             </div>
-          )}
+            {/* @common:endif */}
+          </div>
           {/* @common:endif */}
         </div>
-      ) : (
-        /* @common:if [condition="abTests.dashboardLayout === 'list'"] */
+      </div>
+      {/* @common:endif */}
+
+      {/* Dashboard Layout - List Version */}
+      {/* @common:if [condition="abTests.isListLayout"] */}
+      <div style={{ padding: '15px', border: '1px solid #e9ecef', borderRadius: '8px', marginBottom: '20px' }}>
+        <h3 style={{ color: '#343a40', marginBottom: '15px' }}>
+          Dashboard (list layout)
+        </h3>
         <div style={{ display: 'flex', flexDirection: 'column', gap: '10px' }}>
           <div style={{ padding: '12px', backgroundColor: '#fff3cd', border: '1px solid #ffeaa7', borderRadius: '6px' }}>
             <strong>List Item 1</strong> - Linear layout active
@@ -96,206 +82,173 @@ function ComplexAppRouter({ userType = "free", platform = "desktop", deviceCapab
           <div style={{ padding: '12px', backgroundColor: '#d1ecf1', border: '1px solid #bee5eb', borderRadius: '6px' }}>
             <strong>List Item 2</strong> - Mobile-optimized
           </div>
-          {/* @common:if [condition="featureFlags.advanced-analytics"] */}
-          {hasAdvancedAnalytics && (
-            <div style={{ padding: '12px', backgroundColor: '#d4edda', border: '1px solid #c3e6cb', borderRadius: '6px' }}>
-              <strong>Analytics List View</strong> - Premium features
-            </div>
-          )}
+          {/* @common:if [condition="featureFlags.hasAdvancedAnalytics"] */}
+          <div style={{ padding: '12px', backgroundColor: '#d4edda', border: '1px solid #c3e6cb', borderRadius: '6px' }}>
+            <strong>Analytics List View</strong> - Premium features
+          </div>
           {/* @common:endif */}
         </div>
-        /* @common:endif */
-      )}
+      </div>
       {/* @common:endif */}
-    </div>
-  );
 
-  // Platform-specific features
-  const PlatformFeatures = () => (
-    <div style={{ marginBottom: '20px' }}>
+      {/* Mobile Platform Features */}
       {/* @common:if [condition="platform.isMobile"] */}
-      {isMobile ? (
+      <div style={{ marginBottom: '20px' }}>
         <div style={{ padding: '15px', backgroundColor: '#f8d7da', border: '1px solid #f5c6cb', borderRadius: '8px' }}>
           <h4 style={{ margin: '0 0 10px 0', color: '#721c24' }}>📱 Mobile Features</h4>
           
-          {/* @common:if [condition="featureFlags.mobile-camera"] */}
-          {hasMobileCamera && (
-            <div style={{ marginBottom: '10px', padding: '8px', backgroundColor: '#d1ecf1', borderRadius: '4px' }}>
-              📷 Camera access enabled
-              {/* @common:if [condition="platform.hasWakeLock"] */}
-              {deviceCapabilities.wakeLock && (
-                <div style={{ fontSize: '12px', color: '#0c5460', marginTop: '4px' }}>
-                  🔒 Screen wake lock available
-                </div>
-              )}
-              {/* @common:endif */}
+          {/* @common:if [condition="featureFlags.hasMobileCamera"] */}
+          <div style={{ marginBottom: '10px', padding: '8px', backgroundColor: '#d1ecf1', borderRadius: '4px' }}>
+            📷 Camera access enabled
+            {/* @common:if [condition="platform.hasWakeLock"] */}
+            <div style={{ fontSize: '12px', color: '#0c5460', marginTop: '4px' }}>
+              🔒 Screen wake lock available
             </div>
-          )}
+            {/* @common:endif */}
+          </div>
           {/* @common:endif */}
           
           {/* @common:if [condition="platform.hasDeviceOrientation"] */}
-          {deviceCapabilities.orientation && (
-            <div style={{ padding: '8px', backgroundColor: '#fff3cd', borderRadius: '4px' }}>
-              🧭 Device orientation: {/* @common:define-inline [value="device.orientation" default="portrait"] */"portrait"}
-            </div>
-          )}
+          <div style={{ padding: '8px', backgroundColor: '#fff3cd', borderRadius: '4px' }}>
+            🧭 Device orientation: portrait
+          </div>
           {/* @common:endif */}
         </div>
-      ) : (
-        /* @common:if [condition="platform.isDesktop"] */
+      </div>
+      {/* @common:endif */}
+
+      {/* Desktop Platform Features */}
+      {/* @common:if [condition="platform.isDesktop"] */}
+      <div style={{ marginBottom: '20px' }}>
         <div style={{ padding: '15px', backgroundColor: '#d4edda', border: '1px solid #c3e6cb', borderRadius: '8px' }}>
           <h4 style={{ margin: '0 0 10px 0', color: '#155724' }}>🖥️ Desktop Features</h4>
           
-          {/* @common:if [condition="featureFlags.desktop-shortcuts"] */}
-          {hasDesktopShortcuts && (
-            <div style={{ marginBottom: '10px', padding: '8px', backgroundColor: '#e2e3e5', borderRadius: '4px' }}>
-              ⌨️ Keyboard shortcuts active
-              {/* @common:if [condition="platform.hasWebGL"] */}
-              {deviceCapabilities.webgl && (
-                <div style={{ fontSize: '12px', color: '#383d41', marginTop: '4px' }}>
-                  🎮 WebGL acceleration enabled
-                </div>
-              )}
-              {/* @common:endif */}
+          {/* @common:if [condition="featureFlags.hasDesktopShortcuts"] */}
+          <div style={{ marginBottom: '10px', padding: '8px', backgroundColor: '#e2e3e5', borderRadius: '4px' }}>
+            ⌨️ Keyboard shortcuts active
+            {/* @common:if [condition="platform.hasWebGL"] */}
+            <div style={{ fontSize: '12px', color: '#383d41', marginTop: '4px' }}>
+              🎮 WebGL acceleration enabled
             </div>
-          )}
+            {/* @common:endif */}
+          </div>
           {/* @common:endif */}
           
-          {/* @common:if [condition="featureFlags.advanced-analytics"] */}
-          {hasAdvancedAnalytics && (
-            <div style={{ padding: '8px', backgroundColor: '#cce5ff', borderRadius: '4px' }}>
-              📊 Desktop analytics dashboard
-            </div>
-          )}
+          {/* @common:if [condition="featureFlags.hasAdvancedAnalytics"] */}
+          <div style={{ padding: '8px', backgroundColor: '#cce5ff', borderRadius: '4px' }}>
+            📊 Desktop analytics dashboard
+          </div>
           {/* @common:endif */}
         </div>
-        /* @common:endif */
-      )}
+      </div>
       {/* @common:endif */}
-    </div>
-  );
 
-  // User-specific features  
-  const UserFeatures = () => (
-    <div style={{ marginBottom: '20px' }}>
-      {/* @common:if [condition="user.type === 'enterprise'"] */}
-      {userType === "enterprise" ? (
+      {/* Enterprise User Features */}
+      {/* @common:if [condition="user.isEnterprise"] */}
+      <div style={{ marginBottom: '20px' }}>
         <div style={{ padding: '15px', backgroundColor: '#e7f3ff', border: '1px solid #b3d9ff', borderRadius: '8px' }}>
           <h4 style={{ margin: '0 0 10px 0', color: '#004085' }}>🏢 Enterprise Features</h4>
           
-          {/* @common:if [condition="featureFlags.real-time-collaboration"] */}
-          {hasCollaboration && (
-            <div style={{ marginBottom: '10px', padding: '8px', backgroundColor: '#d1f2eb', borderRadius: '4px' }}>
-              👥 Real-time collaboration enabled
-              {/* @common:if [condition="featureFlags.video-calling"] */}
-              {true && (
-                <div style={{ fontSize: '12px', color: '#0e6655', marginTop: '4px' }}>
-                  📹 Video calling available
-                </div>
-              )}
-              {/* @common:endif */}
+          {/* @common:if [condition="featureFlags.hasCollaboration"] */}
+          <div style={{ marginBottom: '10px', padding: '8px', backgroundColor: '#d1f2eb', borderRadius: '4px' }}>
+            👥 Real-time collaboration enabled
+            {/* @common:if [condition="featureFlags.hasVideoCalling"] */}
+            <div style={{ fontSize: '12px', color: '#0e6655', marginTop: '4px' }}>
+              📹 Video calling available
             </div>
-          )}
+            {/* @common:endif */}
+          </div>
           {/* @common:endif */}
           
-          {/* @common:if [condition="featureFlags.advanced-analytics"] */}
-          {hasAdvancedAnalytics && (
-            <div style={{ padding: '8px', backgroundColor: '#fff2cc', borderRadius: '4px' }}>
-              📈 Enterprise analytics & reporting
-            </div>
-          )}
+          {/* @common:if [condition="featureFlags.hasAdvancedAnalytics"] */}
+          <div style={{ padding: '8px', backgroundColor: '#fff2cc', borderRadius: '4px' }}>
+            📈 Enterprise analytics & reporting
+          </div>
           {/* @common:endif */}
         </div>
-      ) : userType === "premium" ? (
-        /* @common:if [condition="user.type === 'premium'"] */
+      </div>
+      {/* @common:endif */}
+
+      {/* Premium User Features */}
+      {/* @common:if [condition="user.isPremium"] */}
+      <div style={{ marginBottom: '20px' }}>
         <div style={{ padding: '15px', backgroundColor: '#fff0f5', border: '1px solid #ffb3d1', borderRadius: '8px' }}>
           <h4 style={{ margin: '0 0 10px 0', color: '#6d1650' }}>⭐ Premium Features</h4>
           
-          {/* @common:if [condition="featureFlags.advanced-analytics"] */}
-          {hasAdvancedAnalytics && (
-            <div style={{ marginBottom: '10px', padding: '8px', backgroundColor: '#e1f5fe', borderRadius: '4px' }}>
-              📊 Advanced analytics
-            </div>
-          )}
+          {/* @common:if [condition="featureFlags.hasAdvancedAnalytics"] */}
+          <div style={{ marginBottom: '10px', padding: '8px', backgroundColor: '#e1f5fe', borderRadius: '4px' }}>
+            📊 Advanced analytics
+          </div>
           {/* @common:endif */}
           
-          {/* @common:if [condition="featureFlags.ai-suggestions"] */}
+          {/* @common:if [condition="featureFlags.hasAiSuggestions"] */}
           <div style={{ padding: '8px', backgroundColor: '#f3e5f5', borderRadius: '4px' }}>
             🤖 AI-powered suggestions
           </div>
           {/* @common:endif */}
         </div>
-        /* @common:endif */
-      ) : (
-        /* @common:if [condition="user.type === 'free'"] */
+      </div>
+      {/* @common:endif */}
+
+      {/* Free User Features */}
+      {/* @common:if [condition="user.isFree"] */}
+      <div style={{ marginBottom: '20px' }}>
         <div style={{ padding: '15px', backgroundColor: '#f8f9fa', border: '1px solid #dee2e6', borderRadius: '8px' }}>
           <h4 style={{ margin: '0 0 10px 0', color: '#495057' }}>🆓 Free Tier</h4>
           <div style={{ padding: '8px', backgroundColor: '#e9ecef', borderRadius: '4px' }}>
             Basic features available. Upgrade for premium features!
           </div>
         </div>
-        /* @common:endif */
-      )}
-    </div>
-  );
-
-  return (
-    <div style={{ maxWidth: '800px', margin: '0 auto', padding: '20px', fontFamily: 'Arial, sans-serif' }}>
-      <Navigation />
-      <DashboardContent />
-      <PlatformFeatures />
-      <UserFeatures />
+      </div>
+      {/* @common:endif */}
       
+      {/* Admin Panel */}
       {/* @common:if [condition="user.isAdmin"] */}
-      {isAdmin && (
-        <div style={{ 
-          padding: '15px', 
-          backgroundColor: '#fff3cd', 
-          border: '2px solid #ffc107', 
-          borderRadius: '8px',
-          marginBottom: '20px'
-        }}>
-          <h4 style={{ margin: '0 0 10px 0', color: '#856404' }}>🔧 Admin Panel</h4>
-          <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(150px, 1fr))', gap: '10px' }}>
-            <div style={{ padding: '8px', backgroundColor: '#f8d7da', borderRadius: '4px', fontSize: '12px' }}>
-              Feature Flags Control
-            </div>
-            <div style={{ padding: '8px', backgroundColor: '#d1ecf1', borderRadius: '4px', fontSize: '12px' }}>
-              A/B Test Management  
-            </div>
-            <div style={{ padding: '8px', backgroundColor: '#d4edda', borderRadius: '4px', fontSize: '12px' }}>
-              User Analytics
-            </div>
+      <div style={{ 
+        padding: '15px', 
+        backgroundColor: '#fff3cd', 
+        border: '2px solid #ffc107', 
+        borderRadius: '8px',
+        marginBottom: '20px'
+      }}>
+        <h4 style={{ margin: '0 0 10px 0', color: '#856404' }}>🔧 Admin Panel</h4>
+        <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(150px, 1fr))', gap: '10px' }}>
+          <div style={{ padding: '8px', backgroundColor: '#f8d7da', borderRadius: '4px', fontSize: '12px' }}>
+            Feature Flags Control
+          </div>
+          <div style={{ padding: '8px', backgroundColor: '#d1ecf1', borderRadius: '4px', fontSize: '12px' }}>
+            A/B Test Management  
+          </div>
+          <div style={{ padding: '8px', backgroundColor: '#d4edda', borderRadius: '4px', fontSize: '12px' }}>
+            User Analytics
           </div>
         </div>
-      )}
+      </div>
       {/* @common:endif */}
 
-      {/* @common:if [condition="featureFlags.notifications"] */}
-      {hasNotifications && (
-        <div style={{ 
-          position: 'fixed', 
-          top: '10px', 
-          right: '10px', 
-          padding: '10px', 
-          backgroundColor: '#28a745', 
-          color: 'white',
-          borderRadius: '6px',
-          fontSize: '12px',
-          maxWidth: '200px'
-        }}>
-          🔔 Notifications enabled
-          {/* @common:if [condition="platform.isMobile && platform.hasVibration"] */}
-          {isMobile && deviceCapabilities.vibration && (
-            <div style={{ marginTop: '4px', fontSize: '10px' }}>
-              📳 With haptic feedback
-            </div>
-          )}
-          {/* @common:endif */}
+      {/* Notifications */}
+      {/* @common:if [condition="featureFlags.hasNotifications"] */}
+      <div style={{ 
+        position: 'fixed', 
+        top: '10px', 
+        right: '10px', 
+        padding: '10px', 
+        backgroundColor: '#28a745', 
+        color: 'white',
+        borderRadius: '6px',
+        fontSize: '12px',
+        maxWidth: '200px'
+      }}>
+        🔔 Notifications enabled
+        {/* @common:if [condition="platform.hasVibration"] */}
+        <div style={{ marginTop: '4px', fontSize: '10px' }}>
+          📳 With haptic feedback
         </div>
-      )}
+        {/* @common:endif */}
+      </div>
       {/* @common:endif */}
 
+      {/* Build Configuration */}
       <div style={{ 
         marginTop: '30px', 
         padding: '15px', 
@@ -307,20 +260,11 @@ function ComplexAppRouter({ userType = "free", platform = "desktop", deviceCapab
         <strong>Build Configuration:</strong>
         <pre style={{ margin: '8px 0', fontSize: '10px', whiteSpace: 'pre-wrap' }}>
 {JSON.stringify({
-  timestamp: /* @common:define-inline [value="build.timestamp" default="new Date().toISOString()"] */new Date().toISOString(),
-  target: /* @common:define-inline [value="build.target" default="development"] */"development",
+  timestamp: new Date().toISOString(),
+  target: 'production',
   platform,
   userType,
-  abTestVariant,
-  enabledFeatures: {
-    hasAdvancedAnalytics,
-    hasCollaboration,
-    hasMobileCamera,
-    hasDesktopShortcuts,
-    has3DVisualization,
-    hasNotifications,
-    isAdmin
-  }
+  abTestVariant
 }, null, 2)}
         </pre>
       </div>

--- a/test-cases/webpack-bundles/bundle-all-features.js
+++ b/test-cases/webpack-bundles/bundle-all-features.js
@@ -112,8 +112,8 @@ var expensiveUIUtils = {
 __webpack_require__.d(__webpack_exports__, {
   v: () => (featureA)
 });
-/* ESM import */var _heavyMathUtils_ts__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(78);
-/* ESM import */var _dataProcessor_ts__WEBPACK_IMPORTED_MODULE_1__ = __webpack_require__(418);
+/* ESM import */var _heavyMathUtils_ts__WEBPACK_IMPORTED_MODULE_0__ = /*#__PURE__*/ __webpack_require__(78);
+/* ESM import */var _dataProcessor_ts__WEBPACK_IMPORTED_MODULE_1__ = /*#__PURE__*/ __webpack_require__(418);
 // featureA.js - Feature A implementation that uses heavy utilities
 
 
@@ -137,8 +137,8 @@ function featureA() {
 __webpack_require__.d(__webpack_exports__, {
   S: () => (featureB)
 });
-/* ESM import */var _expensiveUIUtils_ts__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(803);
-/* ESM import */var _networkUtils_ts__WEBPACK_IMPORTED_MODULE_1__ = __webpack_require__(812);
+/* ESM import */var _expensiveUIUtils_ts__WEBPACK_IMPORTED_MODULE_0__ = /*#__PURE__*/ __webpack_require__(803);
+/* ESM import */var _networkUtils_ts__WEBPACK_IMPORTED_MODULE_1__ = /*#__PURE__*/ __webpack_require__(812);
 // featureB.js - Feature B implementation that uses different heavy utilities
 
 
@@ -235,6 +235,7 @@ var networkUtils = {
 var __webpack_module_cache__ = {};
 
 // The require function
+/*#__NO_SIDE_EFFECTS__*/
 function __webpack_require__(moduleId) {
 
 // Check if module is in cache
@@ -282,9 +283,9 @@ __webpack_require__.ruid = "bundler=rspack@1.3.12";
 var __webpack_exports__ = {};
 // This entry needs to be wrapped in an IIFE because it needs to be isolated against other modules in the chunk.
 (() => {
-/* ESM import */var _featureA_ts__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(153);
-/* ESM import */var _featureB_ts__WEBPACK_IMPORTED_MODULE_1__ = __webpack_require__(722);
-/* ESM import */var _debugUtils_ts__WEBPACK_IMPORTED_MODULE_2__ = __webpack_require__(422);
+/* ESM import */var _featureA_ts__WEBPACK_IMPORTED_MODULE_0__ = /*#__PURE__*/ __webpack_require__(153);
+/* ESM import */var _featureB_ts__WEBPACK_IMPORTED_MODULE_1__ = /*#__PURE__*/ __webpack_require__(722);
+/* ESM import */var _debugUtils_ts__WEBPACK_IMPORTED_MODULE_2__ = /*#__PURE__*/ __webpack_require__(422);
 // main.js - Entry point demonstrating conditional macro tree shaking
 
 

--- a/test-cases/webpack-bundles/bundle-feature-a-only.js
+++ b/test-cases/webpack-bundles/bundle-feature-a-only.js
@@ -30,8 +30,8 @@ var dataProcessor = {
 __webpack_require__.d(__webpack_exports__, {
   v: () => (featureA)
 });
-/* ESM import */var _heavyMathUtils_ts__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(78);
-/* ESM import */var _dataProcessor_ts__WEBPACK_IMPORTED_MODULE_1__ = __webpack_require__(418);
+/* ESM import */var _heavyMathUtils_ts__WEBPACK_IMPORTED_MODULE_0__ = /*#__PURE__*/ __webpack_require__(78);
+/* ESM import */var _dataProcessor_ts__WEBPACK_IMPORTED_MODULE_1__ = /*#__PURE__*/ __webpack_require__(418);
 // featureA.js - Feature A implementation that uses heavy utilities
 
 function featureA() {
@@ -74,6 +74,7 @@ var heavyMathUtils = {
 var __webpack_module_cache__ = {};
 
 // The require function
+/*#__NO_SIDE_EFFECTS__*/
 function __webpack_require__(moduleId) {
 var cachedModule = __webpack_module_cache__[moduleId];
 if (cachedModule !== undefined) {
@@ -105,7 +106,7 @@ __webpack_require__.o = (obj, prop) => (Object.prototype.hasOwnProperty.call(obj
 /************************************************************************/
 var __webpack_exports__ = {};
 (() => {
-/* ESM import */var _featureA_ts__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(153);
+/* ESM import */var _featureA_ts__WEBPACK_IMPORTED_MODULE_0__ = /*#__PURE__*/ __webpack_require__(153);
 // main.js - Entry point with only Feature A
 
 console.log('=== Feature A Only Demo ===');

--- a/tests/jsx-conditional-rendering.test.js
+++ b/tests/jsx-conditional-rendering.test.js
@@ -81,7 +81,7 @@ describe('JSX Conditional Rendering', () => {
       
       expect(analysis.sizes.reduction).toBeGreaterThan(0);
       
-      validateMacroRemoval(optimized, 'user.type === \'premium\'');
+      validateMacroRemoval(optimized, 'user.isPremium');
       
       saveSnapshot('jsx-enterprise-user', source, optimized, analysis);
     });
@@ -105,7 +105,7 @@ describe('JSX Conditional Rendering', () => {
       
       expect(analysis.sizes.reduction).toBeGreaterThan(0);
       
-      validateMacroRemoval(optimized, 'user.type === \'enterprise\'');
+      validateMacroRemoval(optimized, 'user.isEnterprise');
       
       saveSnapshot('jsx-premium-user', source, optimized, analysis);
     });
@@ -128,7 +128,7 @@ describe('JSX Conditional Rendering', () => {
       
       expect(analysis.sizes.reduction).toBeGreaterThan(0);
       
-      validateMacroRemoval(optimized, 'user.type === \'enterprise\'');
+      validateMacroRemoval(optimized, 'user.isEnterprise');
       
       saveSnapshot('jsx-free-user', source, optimized, analysis);
     });
@@ -154,7 +154,7 @@ describe('JSX Conditional Rendering', () => {
       
       expect(analysis.sizes.reduction).toBeGreaterThan(0);
       
-      validateMacroRemoval(optimized, 'abTests.dashboardLayout === \'list\'');
+      validateMacroRemoval(optimized, 'abTests.isListLayout');
       
       saveSnapshot('jsx-grid-layout', source, optimized, analysis);
     });
@@ -177,7 +177,7 @@ describe('JSX Conditional Rendering', () => {
       
       expect(analysis.sizes.reduction).toBeGreaterThan(0);
       
-      validateMacroRemoval(optimized, 'abTests.dashboardLayout === \'grid\'');
+      validateMacroRemoval(optimized, 'abTests.isGridLayout');
       
       saveSnapshot('jsx-list-layout', source, optimized, analysis);
     });
@@ -203,7 +203,7 @@ describe('JSX Conditional Rendering', () => {
       
       expect(analysis.sizes.reduction).toBeGreaterThan(0);
       
-      validateMacroRemoval(optimized, 'featureFlags.desktop-shortcuts');
+      validateMacroRemoval(optimized, 'featureFlags.hasDesktopShortcuts');
       
       saveSnapshot('jsx-mobile-premium-camera', source, optimized, analysis);
     });
@@ -244,7 +244,7 @@ describe('JSX Conditional Rendering', () => {
       
       expect(analysis.sizes.reduction).toBeGreaterThan(0);
       
-      validateMacroRemoval(optimized, 'featureFlags.advanced-analytics');
+      validateMacroRemoval(optimized, 'featureFlags.hasAdvancedAnalytics');
       
       saveSnapshot('jsx-minimal-config', source, optimized, analysis);
     });

--- a/tests/utils/optimizer.js
+++ b/tests/utils/optimizer.js
@@ -121,7 +121,8 @@ export class SWCOptimizer {
    * Count webpack modules in source
    */
   countWebpackModules(source) {
-    const moduleRegex = /\d+:\s*\(function/g;
+    // Updated regex to handle both (function and function formats
+    const moduleRegex = /\d+:\s*(?:\()?function/g;
     const matches = source.match(moduleRegex);
     return matches ? matches.length : 0;
   }

--- a/tests/utils/test-helpers.js
+++ b/tests/utils/test-helpers.js
@@ -155,25 +155,25 @@ export const TEST_CONFIGS = {
         hasWakeLock: true,
         hasDeviceOrientation: true
       },
-      device: {
-        orientation: 'portrait'
-      },
       featureFlags: {
-        'mobile-camera': true,
-        'desktop-shortcuts': false,
-        'advanced-analytics': false,
-        'real-time-collaboration': false,
-        '3d-visualization': false,
-        'notifications': true,
-        'video-calling': false,
-        'ai-suggestions': false
+        hasMobileCamera: true,
+        hasDesktopShortcuts: false,
+        hasAdvancedAnalytics: false,
+        hasCollaboration: false,
+        has3dVisualization: false,
+        hasNotifications: true,
+        hasVideoCalling: false,
+        hasAiSuggestions: false
       },
       user: {
-        type: 'free',
+        isFree: true,
+        isEnterprise: false,
+        isPremium: false,
         isAdmin: false
       },
       abTests: {
-        dashboardLayout: 'list'
+        isGridLayout: false,
+        isListLayout: true
       },
       build: {
         target: 'production',
@@ -190,21 +190,24 @@ export const TEST_CONFIGS = {
         hasWebGL: true
       },
       featureFlags: {
-        'mobile-camera': false,
-        'desktop-shortcuts': true,
-        'advanced-analytics': false,
-        'real-time-collaboration': false,
-        '3d-visualization': false,
-        'notifications': true,
-        'video-calling': false,
-        'ai-suggestions': false
+        hasMobileCamera: false,
+        hasDesktopShortcuts: true,
+        hasAdvancedAnalytics: false,
+        hasCollaboration: false,
+        has3dVisualization: false,
+        hasNotifications: true,
+        hasVideoCalling: false,
+        hasAiSuggestions: false
       },
       user: {
-        type: 'free',
+        isFree: true,
+        isEnterprise: false,
+        isPremium: false,
         isAdmin: false
       },
       abTests: {
-        dashboardLayout: 'grid'
+        isGridLayout: true,
+        isListLayout: false
       },
       build: {
         target: 'production',
@@ -220,21 +223,24 @@ export const TEST_CONFIGS = {
         hasWebGL: true
       },
       featureFlags: {
-        'mobile-camera': false,
-        'desktop-shortcuts': true,
-        'advanced-analytics': true,
-        'real-time-collaboration': true,
-        '3d-visualization': true,
-        'notifications': true,
-        'video-calling': true,
-        'ai-suggestions': true
+        hasMobileCamera: false,
+        hasDesktopShortcuts: true,
+        hasAdvancedAnalytics: true,
+        hasCollaboration: true,
+        has3dVisualization: true,
+        hasNotifications: true,
+        hasVideoCalling: true,
+        hasAiSuggestions: true
       },
       user: {
-        type: 'enterprise',
+        isEnterprise: true,
+        isPremium: false,
+        isFree: false,
         isAdmin: false
       },
       abTests: {
-        dashboardLayout: 'grid'
+        isGridLayout: true,
+        isListLayout: false
       },
       build: {
         target: 'production',
@@ -248,21 +254,24 @@ export const TEST_CONFIGS = {
         hasWebGL: true
       },
       featureFlags: {
-        'mobile-camera': false,
-        'desktop-shortcuts': true,
-        'advanced-analytics': true,
-        'real-time-collaboration': false,
-        '3d-visualization': true,
-        'notifications': true,
-        'video-calling': false,
-        'ai-suggestions': true
+        hasMobileCamera: false,
+        hasDesktopShortcuts: true,
+        hasAdvancedAnalytics: true,
+        hasCollaboration: false,
+        has3dVisualization: true,
+        hasNotifications: true,
+        hasVideoCalling: false,
+        hasAiSuggestions: true
       },
       user: {
-        type: 'premium',
+        isFree: false,
+        isEnterprise: false,
+        isPremium: true,
         isAdmin: false
       },
       abTests: {
-        dashboardLayout: 'grid'
+        isGridLayout: true,
+        isListLayout: false
       },
       build: {
         target: 'production',
@@ -275,21 +284,24 @@ export const TEST_CONFIGS = {
         isDesktop: true
       },
       featureFlags: {
-        'mobile-camera': false,
-        'desktop-shortcuts': false,
-        'advanced-analytics': false,
-        'real-time-collaboration': false,
-        '3d-visualization': false,
-        'notifications': true,
-        'video-calling': false,
-        'ai-suggestions': false
+        hasMobileCamera: false,
+        hasDesktopShortcuts: false,
+        hasAdvancedAnalytics: false,
+        hasCollaboration: false,
+        has3dVisualization: false,
+        hasNotifications: true,
+        hasVideoCalling: false,
+        hasAiSuggestions: false
       },
       user: {
-        type: 'free',
+        isFree: true,
+        isEnterprise: false,
+        isPremium: false,
         isAdmin: false
       },
       abTests: {
-        dashboardLayout: 'grid'
+        isGridLayout: true,
+        isListLayout: false
       },
       build: {
         target: 'production',
@@ -304,16 +316,19 @@ export const TEST_CONFIGS = {
         isDesktop: true
       },
       featureFlags: {
-        'advanced-analytics': true,
-        '3d-visualization': true,
-        'notifications': true
+        hasAdvancedAnalytics: true,
+        has3dVisualization: true,
+        hasNotifications: true
       },
       user: {
-        type: 'premium',
+        isFree: false,
+        isEnterprise: false,
+        isPremium: true,
         isAdmin: false
       },
       abTests: {
-        dashboardLayout: 'grid'
+        isGridLayout: true,
+        isListLayout: false
       },
       build: {
         target: 'production',
@@ -326,17 +341,20 @@ export const TEST_CONFIGS = {
         isDesktop: false
       },
       featureFlags: {
-        'advanced-analytics': true,
-        '3d-visualization': true,
-        'mobile-camera': true,
-        'notifications': true
+        hasAdvancedAnalytics: true,
+        has3dVisualization: true,
+        hasMobileCamera: true,
+        hasNotifications: true
       },
       user: {
-        type: 'premium',
+        isFree: false,
+        isEnterprise: false,
+        isPremium: true,
         isAdmin: false
       },
       abTests: {
-        dashboardLayout: 'list'
+        isGridLayout: false,
+        isListLayout: true
       },
       build: {
         target: 'production',
@@ -353,25 +371,25 @@ export const TEST_CONFIGS = {
         hasWakeLock: true,
         hasDeviceOrientation: true
       },
-      device: {
-        orientation: 'portrait'
-      },
       featureFlags: {
-        'mobile-camera': true,
-        'desktop-shortcuts': false,
-        'advanced-analytics': true,
-        'real-time-collaboration': false,
-        '3d-visualization': true,
-        'notifications': true,
-        'video-calling': false,
-        'ai-suggestions': true
+        hasMobileCamera: true,
+        hasDesktopShortcuts: false,
+        hasAdvancedAnalytics: true,
+        hasCollaboration: false,
+        has3dVisualization: true,
+        hasNotifications: true,
+        hasVideoCalling: false,
+        hasAiSuggestions: true
       },
       user: {
-        type: 'premium',
+        isFree: false,
+        isEnterprise: false,
+        isPremium: true,
         isAdmin: false
       },
       abTests: {
-        dashboardLayout: 'list'
+        isGridLayout: false,
+        isListLayout: true
       },
       build: {
         target: 'production',
@@ -385,21 +403,24 @@ export const TEST_CONFIGS = {
         hasWebGL: true
       },
       featureFlags: {
-        'mobile-camera': false,
-        'desktop-shortcuts': true,
-        'advanced-analytics': true,
-        'real-time-collaboration': true,
-        '3d-visualization': true,
-        'notifications': true,
-        'video-calling': true,
-        'ai-suggestions': true
+        hasMobileCamera: false,
+        hasDesktopShortcuts: true,
+        hasAdvancedAnalytics: true,
+        hasCollaboration: true,
+        has3dVisualization: true,
+        hasNotifications: true,
+        hasVideoCalling: true,
+        hasAiSuggestions: true
       },
       user: {
-        type: 'admin',
+        isFree: false,
+        isEnterprise: false,
+        isPremium: false,
         isAdmin: true
       },
       abTests: {
-        dashboardLayout: 'grid'
+        isGridLayout: true,
+        isListLayout: false
       },
       build: {
         target: 'production',
@@ -412,21 +433,24 @@ export const TEST_CONFIGS = {
         isDesktop: true
       },
       featureFlags: {
-        'mobile-camera': false,
-        'desktop-shortcuts': false,
-        'advanced-analytics': false,
-        'real-time-collaboration': false,
-        '3d-visualization': false,
-        'notifications': false,
-        'video-calling': false,
-        'ai-suggestions': false
+        hasMobileCamera: false,
+        hasDesktopShortcuts: false,
+        hasAdvancedAnalytics: false,
+        hasCollaboration: false,
+        has3dVisualization: false,
+        hasNotifications: false,
+        hasVideoCalling: false,
+        hasAiSuggestions: false
       },
       user: {
-        type: 'free',
+        isFree: true,
+        isEnterprise: false,
+        isPremium: false,
         isAdmin: false
       },
       abTests: {
-        dashboardLayout: 'grid'
+        isGridLayout: true,
+        isListLayout: false
       },
       build: {
         target: 'production',
@@ -440,19 +464,19 @@ export const TEST_CONFIGS = {
         isMobile: false,
         isDesktop: true
       },
-      device: {
-        orientation: 'portrait'
-      },
       featureFlags: {
-        'advanced-analytics': true,
-        'notifications': true
+        hasAdvancedAnalytics: true,
+        hasNotifications: true
       },
       user: {
-        type: 'premium',
+        isFree: false,
+        isEnterprise: false,
+        isPremium: true,
         isAdmin: false
       },
       abTests: {
-        dashboardLayout: 'grid'
+        isGridLayout: true,
+        isListLayout: false
       },
       build: {
         target: 'production',
@@ -467,25 +491,25 @@ export const TEST_CONFIGS = {
         hasWakeLock: true,
         hasDeviceOrientation: true
       },
-      device: {
-        orientation: 'portrait'
-      },
       featureFlags: {
-        'mobile-camera': true,
-        'desktop-shortcuts': false,
-        'advanced-analytics': true,
-        'real-time-collaboration': true,
-        '3d-visualization': true,
-        'notifications': true,
-        'video-calling': true,
-        'ai-suggestions': true
+        hasMobileCamera: true,
+        hasDesktopShortcuts: false,
+        hasAdvancedAnalytics: true,
+        hasCollaboration: true,
+        has3dVisualization: true,
+        hasNotifications: true,
+        hasVideoCalling: true,
+        hasAiSuggestions: true
       },
       user: {
-        type: 'enterprise',
+        isFree: false,
+        isEnterprise: true,
+        isPremium: false,
         isAdmin: false
       },
       abTests: {
-        dashboardLayout: 'list'
+        isGridLayout: false,
+        isListLayout: true
       },
       build: {
         target: 'production',


### PR DESCRIPTION
This pull request introduces a new module for tree-shaking functionality and refines test output formatting in the `crates/webpack_graph` crate. The most significant changes include adding the `TreeShaker` module and making the test output more concise and professional by removing emojis and simplifying messages.

### New Feature: Tree-Shaking Module
* Added a new module `tree_shaker` and exposed it via `pub mod` and `pub use` statements in `lib.rs`. This module will likely handle tree-shaking operations for the Webpack graph.

### Test Output Refinements
* Removed emojis and informal language from test output messages to make them more concise and professional:
  - Updated success and failure messages in tests to remove emojis like `✅`, `❌`, and `📋`. [[1]](diffhunk://#diff-ffa8efb916b177c89fc2cb4aef36cc0b606910929cfb4422b75eaaf4dd0ccf49L298-R300) [[2]](diffhunk://#diff-ffa8efb916b177c89fc2cb4aef36cc0b606910929cfb4422b75eaaf4dd0ccf49L345-R347) [[3]](diffhunk://#diff-ffa8efb916b177c89fc2cb4aef36cc0b606910929cfb4422b75eaaf4dd0ccf49L523-R525) [[4]](diffhunk://#diff-ffa8efb916b177c89fc2cb4aef36cc0b606910929cfb4422b75eaaf4dd0ccf49L539-R554)
  - Simplified real-world bundle analysis and dependency comparison messages. [[1]](diffhunk://#diff-ffa8efb916b177c89fc2cb4aef36cc0b606910929cfb4422b75eaaf4dd0ccf49L564-R567) [[2]](diffhunk://#diff-ffa8efb916b177c89fc2cb4aef36cc0b606910929cfb4422b75eaaf4dd0ccf49L593-R595) [[3]](diffhunk://#diff-ffa8efb916b177c89fc2cb4aef36cc0b606910929cfb4422b75eaaf4dd0ccf49L665-R667) [[4]](diffhunk://#diff-ffa8efb916b177c89fc2cb4aef36cc0b606910929cfb4422b75eaaf4dd0ccf49L755-L765)